### PR TITLE
feat(registry): add server_only + path_patterns; flip AI packs default

### DIFF
--- a/packs/infra-security/pack.yaml
+++ b/packs/infra-security/pack.yaml
@@ -18,6 +18,7 @@ patterns:
     rule_id: INFRA_DOCKER_PRIVILEGED
     regex: '(?i)privileged:\s*true'
     language: "*"
+    path_patterns: ["**/Dockerfile", "**/Dockerfile.*", "**/*.dockerfile"]
     severity: error
     category: infra
 
@@ -25,6 +26,7 @@ patterns:
     rule_id: INFRA_DOCKER_ROOT
     regex: '(?i)^USER\s+root\s*$'
     language: "*"
+    path_patterns: ["**/Dockerfile", "**/Dockerfile.*", "**/*.dockerfile"]
     severity: warning
     category: infra
     fix_templates:
@@ -34,6 +36,7 @@ patterns:
     rule_id: INFRA_DOCKER_LATEST
     regex: '(?i)^FROM\s+\S+:latest\b'
     language: "*"
+    path_patterns: ["**/Dockerfile", "**/Dockerfile.*", "**/*.dockerfile"]
     severity: warning
     category: infra
     fix_templates:
@@ -43,6 +46,7 @@ patterns:
     rule_id: INFRA_DOCKER_COPY_ALL
     regex: '(?i)^COPY\s+\.\s+\.'
     language: "*"
+    path_patterns: ["**/Dockerfile", "**/Dockerfile.*", "**/*.dockerfile"]
     severity: warning
     category: infra
     fix_templates:
@@ -52,6 +56,7 @@ patterns:
     rule_id: INFRA_DOCKER_ADD_REMOTE
     regex: '(?i)^ADD\s+https?://'
     language: "*"
+    path_patterns: ["**/Dockerfile", "**/Dockerfile.*", "**/*.dockerfile"]
     severity: warning
     category: infra
     fix_templates:
@@ -63,6 +68,7 @@ patterns:
     rule_id: INFRA_K8S_HOSTNET
     regex: '(?i)hostNetwork:\s*true'
     language: "*"
+    path_patterns: ["**/*.yml", "**/*.yaml"]
     severity: error
     category: infra
 
@@ -70,6 +76,7 @@ patterns:
     rule_id: INFRA_K8S_HOSTPID
     regex: '(?i)hostPID:\s*true'
     language: "*"
+    path_patterns: ["**/*.yml", "**/*.yaml"]
     severity: error
     category: infra
 
@@ -77,6 +84,7 @@ patterns:
     rule_id: INFRA_K8S_NO_LIMITS
     regex: '(?i)resources:\s*\{\}'
     language: "*"
+    path_patterns: ["**/*.yml", "**/*.yaml"]
     severity: warning
     category: infra
 
@@ -84,6 +92,7 @@ patterns:
     rule_id: INFRA_K8S_AUTOMOUNT
     regex: '(?i)automountServiceAccountToken:\s*true'
     language: "*"
+    path_patterns: ["**/*.yml", "**/*.yaml"]
     severity: warning
     category: infra
     fix_templates:
@@ -93,6 +102,7 @@ patterns:
     rule_id: INFRA_K8S_WILDCARD_RBAC
     regex: '(?i)resources:\s*\[\s*["'']\*["'']\s*\]'
     language: "*"
+    path_patterns: ["**/*.yml", "**/*.yaml"]
     severity: error
     category: infra
 
@@ -102,6 +112,7 @@ patterns:
     rule_id: INFRA_TF_SECRET
     regex: '(?i)(password|secret|token)\s*=\s*"[^"]{8,}"'
     language: "*"
+    path_patterns: ["**/*.tf", "**/*.tfvars"]
     severity: error
     category: infra
 
@@ -109,6 +120,7 @@ patterns:
     rule_id: INFRA_TF_OPEN_CIDR
     regex: '(?i)cidr_blocks\s*=\s*\[\s*["'']0\.0\.0\.0/0["'']'
     language: "*"
+    path_patterns: ["**/*.tf", "**/*.tfvars"]
     severity: warning
     category: infra
 
@@ -116,6 +128,7 @@ patterns:
     rule_id: INFRA_TF_PUBLIC_S3
     regex: '(?i)acl\s*=\s*["''](public-read|public-read-write)["'']'
     language: "*"
+    path_patterns: ["**/*.tf", "**/*.tfvars"]
     severity: error
     category: infra
 
@@ -123,6 +136,7 @@ patterns:
     rule_id: INFRA_TF_IAM_STAR
     regex: '(?i)actions\s*=\s*\[\s*["'']\*["'']\s*\]'
     language: "*"
+    path_patterns: ["**/*.tf", "**/*.tfvars"]
     severity: error
     category: infra
 
@@ -132,6 +146,7 @@ patterns:
     rule_id: INFRA_GHA_INJECT
     regex: '(?i)\$\{\{\s*github\.event\.(issue|pull_request|comment)\.'
     language: "*"
+    path_patterns: [".github/workflows/**/*.yml", ".github/workflows/**/*.yaml"]
     severity: error
     category: infra
 
@@ -139,6 +154,7 @@ patterns:
     rule_id: INFRA_GHA_PR_TARGET
     regex: '(?i)pull_request_target'
     language: "*"
+    path_patterns: [".github/workflows/**/*.yml", ".github/workflows/**/*.yaml"]
     severity: warning
     category: infra
 
@@ -146,6 +162,7 @@ patterns:
     rule_id: INFRA_GHA_UNPINNED
     regex: '(?i)uses:\s*\S+@(main|master|latest)\b'
     language: "*"
+    path_patterns: [".github/workflows/**/*.yml", ".github/workflows/**/*.yaml"]
     severity: warning
     category: infra
     fix_templates:

--- a/packs/react-security/pack.yaml
+++ b/packs/react-security/pack.yaml
@@ -16,6 +16,7 @@ patterns:
     rule_id: REACT_INNER_HTML
     regex: '(?i)dangerouslySetInnerHTML'
     language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: warning
     category: insecure_pattern
 
@@ -23,6 +24,7 @@ patterns:
     rule_id: REACT_DANGEROUS_HTML
     regex: '(?i)__html\s*:\s*[^''"]'
     language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error
     category: insecure_pattern
 
@@ -30,6 +32,7 @@ patterns:
     rule_id: JS_EVAL
     regex: '(?i)\beval\s*\('
     language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error
     category: insecure_pattern
 
@@ -37,6 +40,7 @@ patterns:
     rule_id: JS_HTTP_URL
     regex: '(?i)http://[a-zA-Z0-9]'
     language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: warning
     category: insecure_pattern
     exclude_pattern: '(?i)http://localhost|http://127\.0\.0\.1|http://0\.0\.0\.0|http://example\.com'
@@ -45,6 +49,7 @@ patterns:
     rule_id: JS_HARDCODED_CREDS
     regex: '(?i)(password|passwd|secret|api_key|apikey|token)\s*[:=]\s*[''"][^''"]{8,}[''"]'
     language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error
     category: insecure_pattern
 
@@ -52,6 +57,7 @@ patterns:
     rule_id: REACT_DIRECT_DOM
     regex: '(?i)document\.(getElementById|querySelector|getElementsBy)'
     language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: warning
     category: insecure_pattern
 
@@ -59,6 +65,7 @@ patterns:
     rule_id: JS_DOCUMENT_WRITE
     regex: '(?i)document\.write\s*\('
     language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error
     category: insecure_pattern
     fix_templates:
@@ -68,6 +75,7 @@ patterns:
     rule_id: JS_POSTMESSAGE
     regex: '(?i)\.addEventListener\s*\(\s*[''"]message[''"]'
     language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: warning
     category: insecure_pattern
     fix_templates:
@@ -77,6 +85,7 @@ patterns:
     rule_id: JS_WINDOW_OPEN
     regex: '(?i)window\.open\s*\(.*(?:params|query|input|user|req)'
     language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error
     category: insecure_pattern
 
@@ -84,6 +93,7 @@ patterns:
     rule_id: JS_NEW_FUNCTION
     regex: '(?i)new\s+Function\s*\('
     language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error
     category: insecure_pattern
     fix_templates:
@@ -93,6 +103,7 @@ patterns:
     rule_id: JS_PROTO_POLLUTION
     regex: '(?i)(__proto__|constructor\.prototype|Object\.assign\s*\(\s*\{\})'
     language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error
     category: insecure_pattern
     fix_templates:
@@ -102,6 +113,7 @@ patterns:
     rule_id: JS_LOCALSTORAGE_SENSITIVE
     regex: '(?i)localStorage\.(setItem|getItem)\s*\(\s*[''"](?:token|jwt|session|auth|password|secret|key|credential)'
     language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: warning
     category: insecure_pattern
     fix_templates:
@@ -111,6 +123,7 @@ patterns:
     rule_id: JS_INNERHTML_ASSIGN
     regex: '(?i)\.outerHTML\s*='
     language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error
     category: insecure_pattern
 
@@ -118,6 +131,7 @@ patterns:
     rule_id: JS_TEMPLATE_UNESCAPED
     regex: '(?i)\$\{.*\}.*\.innerHTML'
     language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error
     category: insecure_pattern
 
@@ -125,6 +139,7 @@ patterns:
     rule_id: JS_OPEN_REDIRECT
     regex: '(?i)(window\.location|location\.href)\s*=\s*(?:params|query|req|request|input)'
     language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error
     category: insecure_pattern
 

--- a/registry.yaml
+++ b/registry.yaml
@@ -107,8 +107,9 @@ packs:
     version: 3
     tags: [ai, governance, detection]
     languages: ["*"]
-    description: Detects AI-generated code via co-author trailers, branch patterns, and tool files
-    default: true
+    description: Detects AI-generated code via co-author trailers, branch patterns, and tool files. Runs on the Pullminder platform only.
+    default: false
+    server_only: true
     author: pullminder
 
   - slug: sensitive-paths
@@ -162,8 +163,9 @@ packs:
     version: 3
     tags: [ai, governance, review]
     languages: ["*"]
-    description: Requires senior reviewer approval for high-risk AI-generated PRs
-    default: true
+    description: Requires senior reviewer approval for high-risk AI-generated PRs. Runs on the Pullminder platform only.
+    default: false
+    server_only: true
     author: pullminder
 
   - slug: java-security

--- a/schema/pack.schema.json
+++ b/schema/pack.schema.json
@@ -105,6 +105,11 @@
             "type": "string",
             "description": "Programming language this pattern applies to"
           },
+          "path_patterns": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Doublestar glob patterns the file path must match for this rule to fire. When non-empty, overrides language-based gating."
+          },
           "severity": {
             "type": "string",
             "enum": ["critical", "error", "warning", "info"],

--- a/schema/registry.schema.json
+++ b/schema/registry.schema.json
@@ -79,6 +79,10 @@
             "type": "boolean",
             "description": "Whether this pack is enabled by default"
           },
+          "server_only": {
+            "type": "boolean",
+            "description": "Whether this pack runs only on the Pullminder platform (not in the local CLI)"
+          },
           "author": {
             "type": "string",
             "description": "Author of the pack"


### PR DESCRIPTION
## Summary

- Mark ai-detection and ai-senior-review as `server_only: true` and flip `default: false`; these packs have no local detection rules and run only on the Pullminder platform. Descriptions get a trailing "Runs on the Pullminder platform only." sentence.
- Add `path_patterns` to all 17 rules in `packs/infra-security` (Docker / K8s / Terraform / GHA globs) and all 15 rules in `packs/react-security` (JS/JSX/TS/TSX).

## Why

`Upmate/pullminder.com#583` (CLI correctness bundle 4) consumes these fields. The PR hand-edited the generated builtins/catalog in the consumer; this PR makes the registry the source of truth so the consumer can regenerate cleanly.

## Compatibility

Both fields are additive. Existing `yaml.v3`-based CLI consumers ignore unknown fields, so older CLI versions keep working as-is. The registry schema version is unchanged because neither field is required.

## Test plan

- [x] `yaml.safe_load` parses all three edited files cleanly.
- [x] `grep -c path_patterns packs/infra-security/pack.yaml` → 17
- [x] `grep -c path_patterns packs/react-security/pack.yaml` → 15
- [ ] Downstream sync-registry in `Upmate/pullminder.com#583` regenerates builtins with zero semantic drift from the hand-edited baseline.