### PR TITLE
ci(registry): daily drift check vs latest pullminder CLI

### DIFF
--- a/.github/workflows/cli-drift.yml
+++ b/.github/workflows/cli-drift.yml
@@ -1,0 +1,95 @@
+name: CLI Drift
+
+on:
+  schedule:
+    - cron: '47 6 * * *'
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout registry
+        uses: actions/checkout@v4
+
+      - name: Detect platform
+        id: plat
+        run: |
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          ARCH=$(uname -m)
+          case "$ARCH" in x86_64) ARCH=amd64;; aarch64|arm64) ARCH=arm64;; esac
+          echo "artifact=pullminder-${OS}-${ARCH}" >> "$GITHUB_OUTPUT"
+
+      - name: Download latest pullminder CLI
+        id: dl
+        run: |
+          set -euo pipefail
+          TAG=$(curl -fsSL https://api.github.com/repos/pullminder/cli/releases/latest | jq -r .tag_name)
+          ART=${{ steps.plat.outputs.artifact }}
+          BASE="https://github.com/pullminder/cli/releases/download/$TAG"
+          curl -fsSL "$BASE/$ART" -o /tmp/pullminder
+          curl -fsSL "$BASE/checksums.txt" -o /tmp/checksums.txt
+          EXPECTED=$(grep " ${ART}\$" /tmp/checksums.txt | awk '{print $1}')
+          ACTUAL=$(sha256sum /tmp/pullminder | awk '{print $1}')
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "::error::checksum mismatch for $ART"
+            exit 1
+          fi
+          chmod +x /tmp/pullminder
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Validate registry against latest CLI release
+        id: validate
+        run: |
+          set +e
+          /tmp/pullminder validate . --strict 2>&1 | tee validate.log
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Fail if validation regressed
+        if: steps.validate.outputs.exit_code != '0'
+        run: |
+          echo "::error::Registry no longer validates against pullminder CLI ${{ steps.dl.outputs.tag }}. The CLI's bundled schemas are out of sync — open an issue in pullminder/pullminder.com."
+          exit 1
+
+      - name: Open or update tracking issue in CLI repo (scheduled only)
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PULLMINDER_CLI_REPO_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const log = fs.readFileSync('validate.log', 'utf8').slice(0, 50000);
+            const tag = '${{ steps.dl.outputs.tag }}';
+            const title = `registry drift: pullminder CLI ${tag} rejects registry@main`;
+            const body = [
+              `Daily registry-side drift check failed. Latest CLI release **${tag}** rejects current registry content.`,
+              '',
+              'Validate output:',
+              '```',
+              log,
+              '```',
+              '',
+              `Source: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            ].join('\n');
+
+            const owner = 'Upmate';
+            const repo  = 'pullminder.com';
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: 'registry-drift',
+            });
+            if (issues.length > 0) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issues[0].number, body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner, repo, title, body, labels: ['registry-drift'],
+              });
+            }

--- a/.github/workflows/cli-drift.yml
+++ b/.github/workflows/cli-drift.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Fail if validation regressed
         if: steps.validate.outputs.exit_code != '0'
         run: |
-          echo "::error::Registry no longer validates against pullminder CLI ${{ steps.dl.outputs.tag }}. The CLI's bundled schemas are out of sync — open an issue in pullminder/pullminder.com."
+          echo "::error::Registry no longer validates against pullminder CLI ${{ steps.dl.outputs.tag }}. The CLI's bundled schemas are out of sync — open an issue in pullminder/cli."
           exit 1
 
       - name: Open or update tracking issue in CLI repo (scheduled only)
@@ -79,8 +79,8 @@ jobs:
               `Source: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             ].join('\n');
 
-            const owner = 'Upmate';
-            const repo  = 'pullminder.com';
+            const owner = 'pullminder';
+            const repo  = 'cli';
             const { data: issues } = await github.rest.issues.listForRepo({
               owner, repo, state: 'open', labels: 'registry-drift',
             });

--- a/.github/workflows/cli-drift.yml
+++ b/.github/workflows/cli-drift.yml
@@ -2,7 +2,7 @@ name: CLI Drift
 
 on:
   schedule:
-    - cron: '47 6 * * *'
+    - cron: "47 6 * * *"
   push:
     branches: [main]
   pull_request:
@@ -49,7 +49,7 @@ jobs:
         id: validate
         run: |
           set +e
-          /tmp/pullminder validate . --strict 2>&1 | tee validate.log
+          /tmp/pullminder registry validate . --strict 2>&1 | tee validate.log
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
 
       - name: Fail if validation regressed

--- a/.github/workflows/cli-drift.yml
+++ b/.github/workflows/cli-drift.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           set +e
           /tmp/pullminder registry validate . --strict 2>&1 | tee validate.log
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Fail if validation regressed
         if: steps.validate.outputs.exit_code != '0'


### PR DESCRIPTION
## Summary

Adds a daily + on-push + on-PR workflow that downloads the latest published `pullminder` CLI release (with SHA256 verification against the release `checksums.txt`) and runs `pullminder registry validate . --strict` against the registry.

If the latest CLI release no longer accepts current registry content, the job fails. On scheduled runs the workflow also opens (or comments on) a tracking issue labelled `registry-drift` in `pullminder/cli` (the public release repo).

## Why

Companion to the schema-sync work in the CLI source repo. This workflow makes the inverse direction observable: when a future registry change adds a field the published CLI doesn't yet accept, we'll see it the next day instead of waiting for a downstream consumer (e.g. `pullminder/action`) to break.

## Required secret

`PULLMINDER_CLI_REPO_TOKEN` — fine-grained PAT with `Issues: read+write` on `pullminder/cli`. Without it, the cross-repo issue step is a no-op (workflow still fails the job, which is the primary signal).

## Known: this PR's CI run is currently red

CLI v0.1.13 (latest at the time of writing) ships stale schemas that reject the current registry. That's the bug the companion CLI PR fixes. Once v0.1.14 ships, this drift workflow goes green. There is also a separate registry-side bug — pullminder/registry#6 — about RE2-incompatible regexes in several packs.

## Test plan

- [ ] Workflow validates YAML and runs on this PR
- [ ] After v0.1.14 ships and registry#6 is resolved, scheduled run is green