### PR TITLE
fix(packs): replace \u escapes and lookaheads with RE2-compatible syntax

### DIFF
--- a/packs/crypto-anti-patterns/pack.yaml
+++ b/packs/crypto-anti-patterns/pack.yaml
@@ -25,21 +25,21 @@ patterns:
 
   - name: Weak cipher (DES/3DES/RC4)
     rule_id: CRYPTO_WEAK_CIPHER
-    regex: '(?i)(?:["\u0027](?:DES|DESede|3DES|RC4|RC2|Blowfish)["\u0027]|Cipher\.getInstance\s*\(\s*["\u0027]DES)'
+    regex: '(?i)(?:["\x{27}](?:DES|DESede|3DES|RC4|RC2|Blowfish)["\x{27}]|Cipher\.getInstance\s*\(\s*["\x{27}]DES)'
     language: "*"
     severity: error
     category: insecure_pattern
 
   - name: ECB mode usage
     rule_id: CRYPTO_ECB_MODE
-    regex: '(?i)(?:["\u0027](?:AES|DES)/ECB|ECB_MODE|MODE_ECB|mode:\s*["\u0027]?ecb)'
+    regex: '(?i)(?:["\x{27}](?:AES|DES)/ECB|ECB_MODE|MODE_ECB|mode:\s*["\x{27}]?ecb)'
     language: "*"
     severity: error
     category: insecure_pattern
 
   - name: Hardcoded initialization vector
     rule_id: CRYPTO_HARDCODED_IV
-    regex: '(?i)(?:iv|initialization.?vector|nonce)\s*[:=]\s*(?:["\u0027][A-Fa-f0-9]{16,}["\u0027]|\[\s*(?:0x[0-9a-f]+\s*,?\s*){4,})'
+    regex: '(?i)(?:iv|initialization.?vector|nonce)\s*[:=]\s*(?:["\x{27}][A-Fa-f0-9]{16,}["\x{27}]|\[\s*(?:0x[0-9a-f]+\s*,?\s*){4,})'
     language: "*"
     severity: error
     category: insecure_pattern

--- a/packs/csharp-security/pack.yaml
+++ b/packs/csharp-security/pack.yaml
@@ -51,7 +51,7 @@ patterns:
 
   - name: Hardcoded connection string
     rule_id: CSHARP_HARDCODED_CONN
-    regex: '(?i)(?:connectionString|ConnectionString)\s*=\s*["\u0027](?:Server|Data Source|Host).*["\u0027]'
+    regex: '(?i)(?:connectionString|ConnectionString)\s*=\s*["\x{27}](?:Server|Data Source|Host).*["\x{27}]'
     language: csharp
     severity: error
     category: secret

--- a/packs/java-security/pack.yaml
+++ b/packs/java-security/pack.yaml
@@ -44,14 +44,14 @@ patterns:
 
   - name: Weak cryptographic algorithm
     rule_id: JAVA_WEAK_CRYPTO
-    regex: '(?i)(?:MessageDigest|Cipher|SecretKeyFactory)\.getInstance\s*\(\s*["\u0027](?:MD5|SHA-?1|DES|DESede|RC4)["\u0027]'
+    regex: '(?i)(?:MessageDigest|Cipher|SecretKeyFactory)\.getInstance\s*\(\s*["\x{27}](?:MD5|SHA-?1|DES|DESede|RC4)["\x{27}]'
     language: java
     severity: error
     category: insecure_pattern
 
   - name: Hardcoded credentials
     rule_id: JAVA_HARDCODED_CREDS
-    regex: '(?i)(?:password|passwd|pwd|secret)\s*=\s*["\u0027][^"\u0027]{4,}["\u0027]'
+    regex: '(?i)(?:password|passwd|pwd|secret)\s*=\s*["\x{27}][^"\x{27}]{4,}["\x{27}]'
     language: java
     severity: error
     category: secret

--- a/packs/kotlin-security/pack.yaml
+++ b/packs/kotlin-security/pack.yaml
@@ -21,7 +21,7 @@ patterns:
 
   - name: Cleartext traffic allowed
     rule_id: KOTLIN_CLEARTEXT
-    regex: '(?i)(?:cleartextTrafficPermitted|usesCleartextTraffic)\s*=\s*["\u0027]?true'
+    regex: '(?i)(?:cleartextTrafficPermitted|usesCleartextTraffic)\s*=\s*["\x{27}]?true'
     language: kotlin
     severity: error
     category: insecure_pattern
@@ -35,7 +35,7 @@ patterns:
 
   - name: Exported component without permission
     rule_id: KOTLIN_EXPORTED_COMPONENT
-    regex: '(?i)android:exported\s*=\s*["\u0027]true["\u0027]'
+    regex: '(?i)android:exported\s*=\s*["\x{27}]true["\x{27}]'
     language: kotlin
     severity: error
     category: insecure_pattern
@@ -49,7 +49,7 @@ patterns:
 
   - name: Hardcoded signing config
     rule_id: KOTLIN_HARDCODED_SIGNING
-    regex: '(?i)(?:storePassword|keyPassword|keyAlias)\s*=?\s*["\u0027][^"\u0027$]{4,}["\u0027]'
+    regex: '(?i)(?:storePassword|keyPassword|keyAlias)\s*=?\s*["\x{27}][^"\x{27}$]{4,}["\x{27}]'
     language: kotlin
     severity: critical
     category: secret

--- a/packs/license-risk/pack.yaml
+++ b/packs/license-risk/pack.yaml
@@ -14,28 +14,28 @@ scoring:
 patterns:
   - name: GPL license reference
     rule_id: LICENSE_GPL
-    regex: '(?i)(?:license|License)\s*[:=]\s*["\u0027](?:GPL|GPLv[23]|GNU General Public License)["\u0027]'
+    regex: '(?i)(?:license|License)\s*[:=]\s*["\x{27}](?:GPL|GPLv[23]|GNU General Public License)["\x{27}]'
     language: "*"
     severity: error
     category: insecure_pattern
 
   - name: AGPL license reference
     rule_id: LICENSE_AGPL
-    regex: '(?i)(?:license|License)\s*[:=]\s*["\u0027](?:AGPL|AGPLv3|GNU Affero General Public License)["\u0027]'
+    regex: '(?i)(?:license|License)\s*[:=]\s*["\x{27}](?:AGPL|AGPLv3|GNU Affero General Public License)["\x{27}]'
     language: "*"
     severity: error
     category: insecure_pattern
 
   - name: SSPL license reference
     rule_id: LICENSE_SSPL
-    regex: '(?i)(?:license|License)\s*[:=]\s*["\u0027](?:SSPL|Server Side Public License)["\u0027]'
+    regex: '(?i)(?:license|License)\s*[:=]\s*["\x{27}](?:SSPL|Server Side Public License)["\x{27}]'
     language: "*"
     severity: error
     category: insecure_pattern
 
   - name: Copyleft license indicator
     rule_id: LICENSE_COPYLEFT
-    regex: '(?i)(?:license|License)\s*[:=]\s*["\u0027](?:EUPL|MPL|EPL|CPAL|OSL|LGPL|CC-BY-SA)["\u0027]'
+    regex: '(?i)(?:license|License)\s*[:=]\s*["\x{27}](?:EUPL|MPL|EPL|CPAL|OSL|LGPL|CC-BY-SA)["\x{27}]'
     language: "*"
     severity: warning
     category: insecure_pattern

--- a/packs/migration-safety/pack.yaml
+++ b/packs/migration-safety/pack.yaml
@@ -35,14 +35,15 @@ patterns:
 
   - name: NOT NULL without DEFAULT
     rule_id: MIGRATION_NOT_NULL_NO_DEFAULT
-    regex: '(?i)\bADD\s+(?:COLUMN\s+)?\w+\s+\w+.*\bNOT\s+NULL\b(?!.*\bDEFAULT\b)'
+    regex: '(?i)\bADD\s+(?:COLUMN\s+)?\w+\s+\w+.*\bNOT\s+NULL\b'
+    exclude_pattern: '(?i)\bDEFAULT\b'
     language: "*"
     severity: error
     category: insecure_pattern
 
   - name: Raw SQL execution in migration
     rule_id: MIGRATION_RAW_SQL
-    regex: '(?i)(?:execute|exec|run)\s*\(\s*["\u0027](?:DELETE|TRUNCATE|DROP|ALTER)\b'
+    regex: '(?i)(?:execute|exec|run)\s*\(\s*["\x{27}](?:DELETE|TRUNCATE|DROP|ALTER)\b'
     language: "*"
     severity: warning
     category: insecure_pattern

--- a/packs/pii-leakage/pack.yaml
+++ b/packs/pii-leakage/pack.yaml
@@ -35,7 +35,7 @@ patterns:
 
   - name: Phone number in code
     rule_id: PII_PHONE
-    regex: '(?i)(?:phone|mobile|tel|fax)\s*[:=]\s*["\u0027]\+?\d[\d\s\-()]{8,}["\u0027]'
+    regex: '(?i)(?:phone|mobile|tel|fax)\s*[:=]\s*["\x{27}]\+?\d[\d\s\-()]{8,}["\x{27}]'
     language: "*"
     severity: warning
     category: insecure_pattern

--- a/packs/shell-security/pack.yaml
+++ b/packs/shell-security/pack.yaml
@@ -42,7 +42,7 @@ patterns:
 
   - name: Hardcoded credentials in scripts
     rule_id: SHELL_HARDCODED_CREDS
-    regex: '(?i)(?:password|passwd|secret|api_key|apikey|token|auth_token)\s*=\s*[\u0027"][^\u0027"$]{4,}[\u0027"]'
+    regex: '(?i)(?:password|passwd|secret|api_key|apikey|token|auth_token)\s*=\s*[\x{27}"][^\x{27}"$]{4,}[\x{27}"]'
     language: shell
     severity: critical
     category: secret

--- a/packs/swift-security/pack.yaml
+++ b/packs/swift-security/pack.yaml
@@ -35,7 +35,7 @@ patterns:
 
   - name: Hardcoded staging/dev URL
     rule_id: SWIFT_HARDCODED_URL
-    regex: '(?i)["\u0027]https?://(?:staging|dev|test|localhost|127\.0\.0\.1|0\.0\.0\.0)'
+    regex: '(?i)["\x{27}]https?://(?:staging|dev|test|localhost|127\.0\.0\.1|0\.0\.0\.0)'
     language: swift
     severity: warning
     category: insecure_pattern


### PR DESCRIPTION
## Summary

Rewrites regex patterns in 9 packs that use Java/PCRE syntax (`\u` escapes, negative lookahead) to RE2-compatible equivalents. The pullminder CLI uses Go's RE2 engine and currently fails to compile these patterns at `validate` time.

`'` (single quote) was replaced with `\x{27}`, the RE2 hex codepoint escape. The `migration-safety` `NOT NULL without DEFAULT` rule used a `(?!.*\bDEFAULT\b)` negative lookahead which RE2 doesn't support — reformulated by stripping the lookahead from the main `regex` and adding `exclude_pattern: '(?i)\bDEFAULT\b'`, preserving rule semantics via the existing exclusion field.

Closes #6.

Affected files:
- packs/java-security/pack.yaml
- packs/csharp-security/pack.yaml
- packs/kotlin-security/pack.yaml
- packs/swift-security/pack.yaml
- packs/shell-security/pack.yaml
- packs/crypto-anti-patterns/pack.yaml
- packs/pii-leakage/pack.yaml
- packs/migration-safety/pack.yaml
- packs/license-risk/pack.yaml

## Test plan

- [x] `pullminder registry validate . --strict` passes locally with 0 errors (25 unrelated slug-collision warnings remain, out of scope)
- [ ] CLI Drift workflow on this PR turns green
- [ ] After merge, `pullminder/action` PR #2 selftest goes green