### PR TITLE
ci(cli-drift): restore --strict now that CLI v0.1.15 skips official self-collision

### DIFF
--- a/.github/workflows/cli-drift.yml
+++ b/.github/workflows/cli-drift.yml
@@ -49,7 +49,7 @@ jobs:
         id: validate
         run: |
           set +e
-          /tmp/pullminder registry validate . 2>&1 | tee validate.log
+          /tmp/pullminder registry validate . --strict 2>&1 | tee validate.log
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Fail if validation regressed


### PR DESCRIPTION
CLI v0.1.15 ships the `isOfficialRegistry()` gate ([Upmate/pullminder.com#623](https://github.com/Upmate/pullminder.com/pull/623)), so validating this registry against itself no longer trips the slug-collision warning.

Re-enable strict mode to catch lint warnings as failures.

The drift workflow downloads the latest CLI release (currently v0.1.15) so the fix is picked up automatically — no version pin to bump.

## Test plan
- [x] `CLI Drift` workflow runs on this PR.
- [x] Job exits 0 against current registry contents.