### PR TITLE
ci: migrate validate workflow from AJV to Pullminder action

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,34 +6,15 @@ on:
 
 jobs:
   validate:
-    name: Validate schemas
+    name: Validate registry
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Validate registry
+        uses: pullminder/action@v1
         with:
-          node-version: "20"
-
-      - name: Install ajv-cli
-        run: npm install -g ajv-cli ajv-formats
-
-      - name: Validate registry.yaml
-        run: ajv validate -s schema/registry.schema.json -d registry.yaml --spec=draft2020 -c ajv-formats
-
-      - name: Validate pack schemas
-        run: |
-          found=0
-          for pack_file in packs/*/pack.yaml; do
-            if [ -f "$pack_file" ]; then
-              echo "Validating $pack_file..."
-              ajv validate -s schema/pack.schema.json -d "$pack_file" --spec=draft2020 -c ajv-formats
-              found=1
-            fi
-          done
-          if [ "$found" -eq 0 ]; then
-            echo "No pack files found to validate. Skipping."
-          fi
+          strict: "true"
+          comment: "true"


### PR DESCRIPTION
## Summary

Migrate `validate.yml` from Node.js AJV-based validation to the `pullminder/action@v1`.

## Changes

- Replaced Node.js setup + `ajv-cli` steps with `pullminder/action@v1`
- Enabled `strict: true` mode for stricter validation
- Kept PR comment output for visibility

## Context

The Pullminder CLI now includes checksum verification (alongside schema validation, regex compilation, duplicate detection, and slug collision checks). This makes the registry pure YAML with all validation logic centralized in the CLI and GitHub Action, eliminating the need for separate Go tooling.

The `cli-drift.yml` workflow (which downloads the CLI directly) remains unchanged.

## Test plan

- [ ] CI passes on this PR
- [ ] Registry validation runs via action in PR comments