### PR TITLE
ci(security): restrict validate job to contents:read

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate schemas


### PR DESCRIPTION
Follow-up to #25 (which merged before the automated commit security review flagged this).

Adds an explicit minimal `permissions:` block to the registry validation workflow:

```yaml
permissions:
  contents: read
```

The job only checks out and runs `pullminder/action@v1` with `comment: "false"` — it never writes to the repo or PRs — so a read-only `GITHUB_TOKEN` is sufficient and caps the blast radius of the downloaded action + CLI binary executing in CI.

No behavior change to validation. `Validate schemas` + `drift` should stay green.