### PR TITLE
fix(migration-safety): scope MIGRATION_DROP_COLUMN to forward (*.up.sql) migrations

### DIFF
--- a/packs/migration-safety/pack.yaml
+++ b/packs/migration-safety/pack.yaml
@@ -3,7 +3,7 @@ name: Migration Safety
 schema_version: 1
 kind: detection
 action: warn
-version: 1
+version: 2
 author: pullminder
 max_weight: 10
 scoring:
@@ -23,6 +23,7 @@ patterns:
     rule_id: MIGRATION_DROP_COLUMN
     regex: '(?i)\bALTER\s+TABLE\s+\w+\s+DROP\s+COLUMN\b'
     language: "*"
+    path_patterns: ["**/*.up.sql"]
     severity: error
     category: insecure_pattern
 

--- a/registry.yaml
+++ b/registry.yaml
@@ -271,13 +271,13 @@ packs:
     name: Migration Safety
     kind: detection
     action: warn
-    version: 1
+    version: 2
     tags: [database, migration, sql, safety]
     languages: ["*"]
     description: Detects dangerous SQL migration patterns (DROP TABLE, type changes, missing defaults)
     default: false
     author: pullminder
-    sha256: 398287736b094d664279379a6ad2e2d3485f9f9f5ccb0ac283580d51a898975b
+    sha256: c32fc3b7fa6d9f6a4591d67c443ed09131eae408978bd3f739c14a0632fb3591
 
   - slug: license-risk
     name: License Risk Detection


### PR DESCRIPTION
Part of Upmate/pullminder.com#984 (rules mis-firing on rollback / non-user-facing paths).

## Problem
`MIGRATION_DROP_COLUMN` fired at `error` on `*.down.sql` rollback migrations (e.g. `apps/api/migrations/040_registry_pack_checksum.down.sql`). A down-migration **must** drop the column its `*.up.sql` added — correct rollback, not a destructive defect.

## Fix
Add `path_patterns: ["**/*.up.sql"]` to `MIGRATION_DROP_COLUMN` so the destructive check only evaluates forward migrations. Other migration rules (DROP TABLE, type changes, NOT NULL, raw SQL) are unchanged.

## Notes
- **Server-side effect depends on Upmate/pullminder.com#993** (the API `path_patterns` parity fix). The CLI already honors `path_patterns`; until #993 merges the posted review still evaluates the rule on every path.
- Tradeoff: projects using flat `NNN_name.sql` migrations (no up/down split) no longer trigger this single rule; DROP TABLE and the rest still apply.
- `pullminder registry validate --strict` ✓. Pack version 1→2, registry index + sha256 updated.