### PR TITLE
chore: add CODEOWNERS to route PRs to maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @upmate/pullminder


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` routing all PR reviews to `@upmate/pullminder`
- Complements existing metadata files (LICENSE, README, CONTRIBUTING, issue templates) already present in the repo

## Test plan
- [ ] Verify CODEOWNERS file exists at `.github/CODEOWNERS`
- [ ] Verify content is `* @upmate/pullminder`

Closes: Upmate/pullminder.com#533