### PR TITLE
docs: fix pack schema drift in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,38 +9,46 @@ Each pack lives in its own directory under `packs/<slug>/` and must contain a `p
 ### pack.yaml Schema
 
 ```yaml
-slug: secrets # Unique identifier (lowercase, hyphens only)
-name: Secrets Detection # Human-readable name
-kind: detection # Pack kind: "detection" or "policy"
-action: flag # Action: "flag", "block", or "warn"
-version: 1.0.0 # Semantic version of the pack
-schema_version: 1 # Schema version (currently 1)
-author: pullminder # Author name or GitHub handle
-max_weight: 10 # Maximum weight this pack can contribute to overall score
+slug: my-check                 # Unique identifier (lowercase, hyphens only)
+name: My Check                 # Human-readable name
+kind: detection                # Pack kind: "detection" or "policy"
+action: warn                   # Action: "flag", "warn", or "block"
+version: 3                     # Integer version of the pack
+schema_version: 1              # Schema version (currently 1)
+author: pullminder             # Author name or GitHub handle
+max_weight: 10                 # Maximum weight this pack can contribute to overall score
 
-scoring:
-  model: additive # Scoring model: "additive" or "weighted"
-  base_weight: 5 # Base weight when any pattern matches
+scoring:                       # Tiered scoring thresholds
+  - min_findings: 1
+    score: 5
+  - min_findings: 3
+    score: 10
 
-patterns:
+patterns:                      # Detection patterns (required for detection packs)
   - name: AWS Access Key
     rule_id: SEC-001
     regex: "AKIA[0-9A-Z]{16}"
-    language: "*" # Language filter: "*" for all, or specific like "go", "python"
-    severity: critical # Severity: "critical", "high", "medium", "low", "info"
-    category: credentials
-    fix_templates:
-      - "Move this credential to an environment variable"
-      - "Use a secrets manager such as AWS Secrets Manager or HashiCorp Vault"
+    language: "*"              # Language filter: "*" for all, or specific like "go", "python"
+    severity: critical         # Severity: "critical", "error", "high", "medium", "low", "info"
+    category: security
+    description: >
+      AWS access keys should never appear in source code.
+      Use environment variables or a secrets manager instead.
+    fix_templates:             # Suggested fixes keyed by language
+      go: 'os.Getenv("AWS_ACCESS_KEY_ID")'
+      python: 'os.environ["AWS_ACCESS_KEY_ID"]'
+      javascript: 'process.env.AWS_ACCESS_KEY_ID'
 
   - name: Generic Password Assignment
     rule_id: SEC-002
     regex: "(?i)(password|passwd|pwd)\\s*[:=]\\s*[\"'][^\"']{4,}[\"']"
     language: "*"
     severity: high
-    category: credentials
+    category: security
     fix_templates:
-      - "Replace hardcoded password with an environment variable reference"
+      go: 'os.Getenv("DB_PASSWORD")'
+      python: 'os.environ["DB_PASSWORD"]'
+      javascript: 'process.env.DB_PASSWORD'
 
 overrides:
   ignore_paths:
@@ -51,33 +59,36 @@ overrides:
 
 ### Top-Level Fields
 
-| Field            | Type    | Required | Description                                                                                      |
-| ---------------- | ------- | -------- | ------------------------------------------------------------------------------------------------ |
-| `slug`           | string  | Yes      | Unique pack identifier. Lowercase letters and hyphens only.                                      |
-| `name`           | string  | Yes      | Human-readable display name.                                                                     |
-| `kind`           | string  | Yes      | Either `detection` (finds patterns in code) or `policy` (enforces workflow rules).               |
-| `action`         | string  | Yes      | What happens on match: `flag` (add comment), `block` (request changes), or `warn` (add warning). |
-| `version`        | string  | Yes      | Semantic version of the pack (e.g., `1.0.0`).                                                    |
-| `schema_version` | integer | Yes      | Must be `1` for the current schema.                                                              |
-| `author`         | string  | Yes      | Author name or GitHub handle.                                                                    |
-| `max_weight`     | integer | Yes      | Maximum score weight this pack can contribute (1-10).                                            |
-| `scoring`        | object  | Yes      | Scoring configuration with `model` and `base_weight`.                                            |
-| `patterns`       | array   | Yes      | List of detection patterns (see below).                                                          |
-| `overrides`      | object  | No       | Optional overrides such as `ignore_paths`.                                                       |
+| Field            | Type    | Required | Description                                                                                               |
+| ---------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------- |
+| `slug`           | string  | Yes      | Unique pack identifier. Lowercase letters, numbers, and hyphens only.                                     |
+| `name`           | string  | Yes      | Human-readable display name.                                                                              |
+| `kind`           | string  | Yes      | Either `detection` (pattern matching against diffs) or `policy` (workflow rules).                         |
+| `action`         | string  | Yes      | Default action when findings are produced: `flag` (reviewer brief only), `warn` (inline PR comments), or `block` (status check failure). |
+| `version`        | integer | Yes      | Integer version number (e.g., `3`). Increment each time you modify patterns or configuration.             |
+| `schema_version` | integer | Yes      | Must be `1` for the current schema.                                                                       |
+| `author`         | string  | Yes      | Author name or GitHub handle.                                                                             |
+| `max_weight`     | integer | No       | Maximum weight a single finding from this pack can contribute to the risk score (1-100). Defaults to 10.  |
+| `scoring`        | array   | No       | Tiered scoring thresholds. Each entry defines `min_findings` (int) and `score` (number).                  |
+| `patterns`       | array   | Yes*     | List of detection patterns. Required for `detection` packs.                                               |
+| `overrides`      | object  | No       | Optional overrides such as `ignore_paths` and `ignore_authors`.                                           |
 
 ### Pattern Fields
 
 Each entry in the `patterns` array defines a single detection rule.
 
-| Field           | Type   | Required | Description                                                                                     |
-| --------------- | ------ | -------- | ----------------------------------------------------------------------------------------------- |
-| `name`          | string | Yes      | Human-readable name of the pattern.                                                             |
-| `rule_id`       | string | Yes      | Unique rule identifier within the pack (e.g., `SEC-001`).                                       |
-| `regex`         | string | Yes      | Regular expression to match against file contents. Must be valid RE2 syntax.                    |
-| `language`      | string | Yes      | Language filter. Use `*` for all languages, or a specific language like `go`, `python`, `rust`. |
-| `severity`      | string | Yes      | Impact level: `critical`, `high`, `medium`, `low`, or `info`.                                   |
-| `category`      | string | Yes      | Category grouping (e.g., `credentials`, `injection`, `misconfiguration`).                       |
-| `fix_templates` | array  | No       | List of suggested fix descriptions shown to the developer.                                      |
+| Field            | Type   | Required | Description                                                                                     |
+| ---------------- | ------ | -------- | ----------------------------------------------------------------------------------------------- |
+| `name`           | string | Yes      | Human-readable name of the pattern.                                                             |
+| `rule_id`        | string | Yes      | Unique rule identifier within the pack (e.g., `SEC-001`). Convention: `UPPER_SNAKE_CASE`.       |
+| `regex`          | string | Yes      | Regular expression to match against file contents. Must be valid RE2 syntax (Go-compatible).    |
+| `language`       | string | Yes      | Language filter. Use `*` for all languages, or a specific language like `go`, `python`, `rust`. |
+| `severity`       | string | Yes      | Impact level: `critical`, `error`, `high`, `medium`, `low`, or `info`.                          |
+| `category`       | string | Yes      | Category grouping (e.g., `security`, `credentials`, `injection`, `code-quality`).               |
+| `description`    | string | No       | Longer explanation of what the pattern detects and why it matters.                              |
+| `fix_templates`  | object | No       | Suggested fixes keyed by language (e.g., `go: ...`, `python: ...`).                              |
+| `exclude_pattern`| string | No       | Regex pattern to exclude false positives within matched lines.                                  |
+| `path_patterns`  | array  | No       | Glob patterns restricting which file paths the rule applies to. Overrides language-based gating. |
 
 ## Creating a New Pack
 
@@ -106,8 +117,12 @@ Each entry in the `patterns` array defines a single detection rule.
    ```
 
    The `sha256` field lets the Pullminder API reject any `pack.yaml` content
-   that has been tampered with in transit. Anyone who edits `pack.yaml` must
-   recompute and update this value in the same commit.
+   that has been tampered with in transit. **Every time you edit `pack.yaml`,**
+   recompute its sha256 and update the value in `registry.yaml` in the same commit:
+
+   ```bash
+   sha256sum packs/<slug>/pack.yaml | awk '{print $1}'
+   ```
 
 5. **Verify locally** before pushing:
 
@@ -140,18 +155,21 @@ CI automatically validates all packs on every pull request:
 
 - **Schema validation.** Every `pack.yaml` is validated against `schema/pack.schema.json`. The registry itself is validated against `schema/registry.schema.json`.
 
-- **Regex compilation.** All regex patterns are compiled to ensure they are valid.
+- **Regex compilation.** All regex patterns are compiled to ensure they are valid Go RE2 syntax.
 
 - **Per-pack sha256 checksums.** `pullminder registry validate --strict` rejects any pack whose `registry.yaml` `sha256` does not match the actual `pack.yaml` content (or is missing).
 
 - **Duplicate detection.** CI checks for duplicate slugs and rule IDs.
 
-To run validation locally before submitting:
+Run validation locally before submitting:
 
 ```bash
-npm install -g ajv-cli ajv-formats
-ajv validate -s schema/pack.schema.json -d "packs/*/pack.yaml" --spec=draft2020 -c ajv-formats
-ajv validate -s schema/registry.schema.json -d registry.yaml --spec=draft2020 -c ajv-formats
+# Recommended: full validation including regex compile and sha256 checks
+pullminder registry validate --strict
+
+# Alternative: JSON schema validation only (what CI also runs)
+npx ajv-cli validate -s schema/pack.schema.json -d "packs/*/pack.yaml" --spec=draft2020 -c ajv-formats
+npx ajv-cli validate -s schema/registry.schema.json -d registry.yaml --spec=draft2020 -c ajv-formats
 ```
 
 ## Code of Conduct


### PR DESCRIPTION
## Summary
- Fix `version` field type in CONTRIBUTING.md pack schema: semver string → integer (matching actual packs and JSON schema)
- Fix `scoring` model: `{model, base_weight}` → tiered `[{min_findings, score}]` array (matching actual packs)
- Fix `action` descriptions: correct the meaning of `flag`, `warn`, `block` actions
- Fix `fix_templates` format: array of strings → object keyed by language (matching actual packs)
- Add missing pattern fields to reference table: `description`, `exclude_pattern`, `path_patterns`
- Update CI validation section: recommend `pullminder registry validate --strict` as primary local check
- Add explicit `sha256sum` recompute command for `registry.yaml` updates

## Test plan
- [x] All external URLs in README.md and CONTRIBUTING.md resolve (HTTP 200)
- [x] No `docs.pullminder.com` links found in any `packs/*/pack.yaml` files — Starlight sidebar verification item is a no-op
- [ ] CI schema validation passes (`ajv validate -s schema/pack.schema.json`)
- [ ] CI `pullminder registry validate --strict` passes

## Link audit findings
All unique external URLs in the registry repo return HTTP 200. No broken links were found.

## Follow-up issues
- #31 — `pack.schema.json` enums diverge from actual pack.yaml values (action, severity, category)

Refs Upmate/pullminder.com#638