### PR TITLE
security: redact monorepo references and secret names from workflow files

### DIFF
--- a/.github/workflows/cli-drift.yml
+++ b/.github/workflows/cli-drift.yml
@@ -58,15 +58,17 @@ jobs:
           echo "::error::Registry no longer validates against pullminder CLI ${{ steps.dl.outputs.tag }}. The CLI's bundled schemas are out of sync — open an issue in pullminder/cli."
           exit 1
 
-      - name: Open or update tracking issue in CLI repo (scheduled only)
+      - name: Open or update drift tracking issue
         if: failure() && github.event_name == 'schedule'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PULLMINDER_CLI_REPO_TOKEN }}
+          github-token: ${{ secrets.TRACKER_TOKEN }}
           script: |
             const fs = require('fs');
             const log = fs.readFileSync('validate.log', 'utf8').slice(0, 50000);
             const tag = '${{ steps.dl.outputs.tag }}';
+            const targetOwner = process.env.TRACKER_OWNER;
+            const targetRepo = process.env.TRACKER_REPO;
             const title = `registry drift: pullminder CLI ${tag} rejects registry@main`;
             const body = [
               `Daily registry-side drift check failed. Latest CLI release **${tag}** rejects current registry content.`,
@@ -79,17 +81,18 @@ jobs:
               `Source: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             ].join('\n');
 
-            const owner = 'pullminder';
-            const repo  = 'cli';
             const { data: issues } = await github.rest.issues.listForRepo({
-              owner, repo, state: 'open', labels: 'registry-drift',
+              owner: targetOwner, repo: targetRepo, state: 'open', labels: 'registry-drift',
             });
             if (issues.length > 0) {
               await github.rest.issues.createComment({
-                owner, repo, issue_number: issues[0].number, body,
+                owner: targetOwner, repo: targetRepo, issue_number: issues[0].number, body,
               });
             } else {
               await github.rest.issues.create({
-                owner, repo, title, body, labels: ['registry-drift'],
+                owner: targetOwner, repo: targetRepo, title, body, labels: ['registry-drift'],
               });
             }
+        env:
+          TRACKER_OWNER: ${{ vars.TRACKER_OWNER }}
+          TRACKER_REPO: ${{ vars.TRACKER_REPO }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,16 +50,18 @@ jobs:
               generate_release_notes: true,
             });
 
-      - name: Notify pullminder.com
+      - name: Dispatch registry update
         if: steps.version_check.outputs.changed == 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PULLMINDER_DISPATCH_TOKEN }}
+          github-token: ${{ secrets.SINK_TOKEN }}
           script: |
+            const owner = process.env.SINK_OWNER;
+            const repo = process.env.SINK_REPO;
             const version = process.env.REGISTRY_VERSION;
             await github.rest.repos.createDispatchEvent({
-              owner: 'Upmate',
-              repo: 'pullminder.com',
+              owner,
+              repo,
               event_type: 'registry-updated',
               client_payload: {
                 sha: context.sha,
@@ -68,4 +70,6 @@ jobs:
               }
             });
         env:
+          SINK_OWNER: ${{ vars.SINK_OWNER }}
+          SINK_REPO: ${{ vars.SINK_REPO }}
           REGISTRY_VERSION: ${{ steps.version_check.outputs.current }}


### PR DESCRIPTION
## Summary

Replaces hardcoded owner/repo strings and descriptive secret names in
`release.yml` and `cli-drift.yml` with opaque repository variables and
secrets. This removes internal infrastructure references from publicly
readable workflow files.

## Changes

- **release.yml** — `Upmate`/`pullminder.com` dispatch target and
  `PULLMINDER_DISPATCH_TOKEN` replaced by `SINK_OWNER`/`SINK_REPO` repo
  variables and `SINK_TOKEN` secret. Step renamed to "Dispatch registry
  update".
- **cli-drift.yml** — `pullminder`/`cli` issue tracker target and
  `PULLMINDER_CLI_REPO_TOKEN` replaced by `TRACKER_OWNER`/`TRACKER_REPO`
  repo variables and `TRACKER_TOKEN` secret. Step renamed to "Open or
  update drift tracking issue".

## Test plan

- [ ] `release.yml` contains no literal `Upmate` or `pullminder.com` strings
- [ ] `cli-drift.yml` contains no literal `'pullminder'` or `'cli'` in the
  script block owner/repo position
- [ ] Secret names `PULLMINDER_DISPATCH_TOKEN` and
  `PULLMINDER_CLI_REPO_TOKEN` are absent from both files
- [ ] New `SINK_OWNER`, `SINK_REPO`, `TRACKER_OWNER`, `TRACKER_REPO`
  variables exist in repo settings before merge
- [ ] New `SINK_TOKEN` and `TRACKER_TOKEN` secrets exist in repo settings
  before merge

## Manual setup required (before merge)

These must be created in this repo's Settings > Secrets and variables >
Actions:

### Variables

| Name | Value |
|---|---|
| `SINK_OWNER` | `Upmate` |
| `SINK_REPO` | `pullminder.com` |
| `TRACKER_OWNER` | `pullminder` |
| `TRACKER_REPO` | `cli` |

### Secrets

| Name | Value |
|---|---|
| `SINK_TOKEN` | Fine-grained PAT with `Actions: write` on `Upmate/pullminder.com` |
| `TRACKER_TOKEN` | Fine-grained PAT with `Issues: write` on `pullminder/cli` |

## After merge

1. Verify workflows run successfully (trigger manually if needed).
2. Delete old secrets `PULLMINDER_DISPATCH_TOKEN` and
   `PULLMINDER_CLI_REPO_TOKEN`.
3. Revoke old tokens in GitHub Developer Settings.