### PR TITLE
feat(sensitive-paths): bump to v4 with auth/ exclude_paths for route files

### DIFF
--- a/packs/sensitive-paths/pack.yaml
+++ b/packs/sensitive-paths/pack.yaml
@@ -2,7 +2,7 @@ slug: sensitive-paths
 name: Sensitive Paths
 kind: detection
 action: warn
-version: 3
+version: 4
 schema_version: 1
 author: pullminder
 max_weight: 20
@@ -16,6 +16,9 @@ scoring:
 paths:
   - pattern: "auth/"
     label: Authentication
+    exclude_paths:
+      - "routes.go"
+      - "handler.go"
   - pattern: "billing/"
     label: Billing
   - pattern: "infra/"

--- a/registry.yaml
+++ b/registry.yaml
@@ -126,7 +126,7 @@ packs:
     name: Sensitive Paths
     kind: detection
     action: warn
-    version: 3
+    version: 4
     tags: [governance, paths, review]
     languages: ["*"]
     description: Flags modifications to security-critical directories


### PR DESCRIPTION
## Summary
- Add `exclude_paths` to the `auth/` pattern entry to skip `routes.go` and `handler.go`
- Bump pack version from 3 to 4
- Update registry.yaml version reference

## Context
Trivial route registration file changes under `auth/` (e.g., changing HTTP method for a logout route) currently get flagged as sensitive path modifications. The `exclude_paths` field lets pack authors declare file substrings to skip on a per-pattern basis, reducing false positives without creating blind spots for real auth logic changes.

## Test plan
- [ ] Verify pack YAML parses correctly with new `exclude_paths` field
- [ ] Confirm `auth/routes.go` changes are excluded while `auth/login.go` changes are still flagged