### PR TITLE
fix(secrets): exclude shell env var references from Generic Secret detection

### DIFF
--- a/packs/secrets/pack.yaml
+++ b/packs/secrets/pack.yaml
@@ -2,7 +2,7 @@ slug: secrets
 name: Secrets Detection
 kind: detection
 action: block
-version: 7
+version: 8
 schema_version: 1
 author: pullminder
 max_weight: 20
@@ -50,7 +50,7 @@ patterns:
   - name: Generic Secret
     rule_id: SECRET_GENERIC_SECRET
     regex: '(?i)(secret|password|passwd|token)\s*[:=]\s*[''"][A-Za-z0-9\-_!@#$%^&*]{8,}'
-    exclude_pattern: '(?i)^\s*(//|#|/\*|\*)|\bX-[A-Za-z]+-Token\b|\bX-CSRF\b|\bX-Auth\b'
+    exclude_pattern: '^\s*(//|#|/\*|\*)|\$\{?[A-Z][A-Z0-9_]*\}?|(?i)\bX-[A-Za-z]+-Token\b|\bX-CSRF\b|\bX-Auth\b'
     language: "*"
     severity: critical
     category: secret

--- a/registry.yaml
+++ b/registry.yaml
@@ -5,13 +5,13 @@ packs:
     name: Secrets Detection
     kind: detection
     action: block
-    version: 7
+    version: 8
     tags: [secrets, owasp, credentials]
     languages: ["*"]
     description: Detects hardcoded secrets, API keys, tokens, and connection strings
     default: true
     author: pullminder
-    sha256: 8a19ff0fec9f7daa9f305ce59249c2ec831fb09823dab903422a930ed52b1e0f
+    sha256: 51fb5d53b606653b6683c7bd3fa6778b8be987fe8c61fa70311421fecd2ae69f
 
   - slug: go-security
     name: Go Security


### PR DESCRIPTION
## Summary
- Append exclude_pattern alternation `\$\{?[A-Z][A-Z0-9_]*\}?` to `SECRET_GENERIC_SECRET` to suppress false positives on shell variable expansions like `$INFISICAL_CLIENT_SECRET`
- The env var branch is placed before the `(?i)` flag to keep it case-sensitive — `[A-Z]` matches only uppercase variables under RE2, preventing exclusion of lowercase identifiers and positional parameters like `$1`
- Bump pack version from 7 to 8 and update SHA256 hash in registry manifest
- Existing comment-line and HTTP-header exclusions are preserved

## Test plan
- [x] Registry validation passes (`pullminder registry validate --strict`)
- [x] Go RE2 regex tests pass — true positives still fire, false positive env var refs excluded
- [x] Existing comment and HTTP header exclusions still work

## Affected detection
- `SECRET_GENERIC_SECRET` — only the `exclude_pattern` field changed; the main regex and severity are unchanged

Fixes Upmate/pullminder.com#1184