### PR TITLE
fix(dependency-detection): add Pipfile to pack manifest_files (#1618)

### DIFF
--- a/packs/dependency-detection/pack.yaml
+++ b/packs/dependency-detection/pack.yaml
@@ -2,7 +2,7 @@ slug: dependency-detection
 name: Dependency Detection
 kind: detection
 action: warn
-version: 4
+version: 5
 schema_version: 1
 author: pullminder
 customizable: false
@@ -31,6 +31,9 @@ manifest_files:
     ecosystem: go
     is_lockfile: true
   - file: requirements.txt
+    ecosystem: python
+    is_lockfile: false
+  - file: Pipfile
     ecosystem: python
     is_lockfile: false
   - file: pyproject.toml

--- a/registry.yaml
+++ b/registry.yaml
@@ -138,13 +138,13 @@ packs:
     name: Dependency Detection
     kind: detection
     action: warn
-    version: 4
+    version: 5
     tags: [dependencies, supply-chain]
     languages: ["*"]
     description: Detects dependency manifest and lockfile changes
     default: true
     author: pullminder
-    sha256: aaa4df7a37a15850d68eb3d225eb359040e702f0df49b4d6ac97542cccdd78c0
+    sha256: 4a4ca2e8990758212f11ffd832e80dbe146da2fa4f3bbc3bc259adf42dc15044
 
   - slug: test-conventions
     name: Test Conventions


### PR DESCRIPTION
## Summary

`Pipfile` was present in the scanner's hardcoded `defaultManifestFiles` but absent from the `dependency-detection` pack's `manifest_files`. Because the pack is `default: true` in `registry.yaml`, the production API reads the pack's `manifest_files` and passes them to `DependencyChangeAnalyzer`, overriding the hardcoded fallback. The result: any PR that touches only a `Pipfile` (Pipenv projects) produced zero dependency findings in production — a silent miss.

## Changes

- Added `Pipfile` entry (`ecosystem: python`, `is_lockfile: false`) to `packs/dependency-detection/pack.yaml`, positioned after `requirements.txt` to match the ordering in `defaultManifestFiles`.
- Bumped pack `version` from 4 to 5.
- Updated `sha256` in `registry.yaml` to match the new pack content.

## Verification

SHA256 of the updated pack.yaml was computed from raw file bytes:

```
sha256sum packs/dependency-detection/pack.yaml
4a4ca2e8990758212f11ffd832e80dbe146da2fa4f3bbc3bc259adf42dc15044
```

This matches the value in `registry.yaml`.

## Related

- Pullminder.com ticket: Upmate/pullminder.com#1618
- After this PR merges, `DefaultOfficialRegistryRef` in `apps/api/internal/registry/sync.go` must be bumped to this merge commit to ship the fix to production (tracked in a follow-up issue).