### PR TITLE
fix(crypto-anti-patterns): narrow CRYPTO_CUSTOM_IMPL to match only crypto keywords at start of identifier

### DIFF
--- a/packs/crypto-anti-patterns/pack.yaml
+++ b/packs/crypto-anti-patterns/pack.yaml
@@ -60,7 +60,7 @@ patterns:
 
   - name: Custom crypto implementation
     rule_id: CRYPTO_CUSTOM_IMPL
-    regex: '(?i)(?:class|function|func|def)\s+\w*(?:encrypt|decrypt|cipher|hash|hmac)\w*\s*\('
+    regex: '(?i)(?:class|function|func|def)\s+(?:encrypt|decrypt|cipher|hash|hmac)\w*\s*\('
     language: "*"
     severity: warning
     category: insecure_pattern


### PR DESCRIPTION
## Summary
- Remove leading `\w*` from CRYPTO_CUSTOM_IMPL regex
- Functions like `validateHash`, `getPasswordHash`, `isEncryptedField` no longer trigger false positives
- Related PR: https://github.com/Upmate/pullminder.com/pull/1731