### PR TITLE
fix(dependency-detection): add Pipfile to manifest_files, bump to v5

### DIFF
--- a/packs/dependency-detection/pack.yaml
+++ b/packs/dependency-detection/pack.yaml
@@ -2,7 +2,7 @@ slug: dependency-detection
 name: Dependency Detection
 kind: detection
 action: warn
-version: 4
+version: 5
 schema_version: 1
 author: pullminder
 customizable: false
@@ -34,6 +34,9 @@ manifest_files:
     ecosystem: python
     is_lockfile: false
   - file: pyproject.toml
+    ecosystem: python
+    is_lockfile: false
+  - file: Pipfile
     ecosystem: python
     is_lockfile: false
   - file: poetry.lock

--- a/registry.yaml
+++ b/registry.yaml
@@ -138,13 +138,13 @@ packs:
     name: Dependency Detection
     kind: detection
     action: warn
-    version: 4
+    version: 5
     tags: [dependencies, supply-chain]
     languages: ["*"]
     description: Detects dependency manifest and lockfile changes
     default: true
     author: pullminder
-    sha256: aaa4df7a37a15850d68eb3d225eb359040e702f0df49b4d6ac97542cccdd78c0
+    sha256: d69127932182c8973487700e63000ab5ff9880c83e7e551f212da5cb106ad9fc
 
   - slug: test-conventions
     name: Test Conventions


### PR DESCRIPTION
## Summary

- Adds `Pipfile` (Python ecosystem, `is_lockfile: false`) to `manifest_files` after `pyproject.toml`, keeping Python ecosystem entries grouped
- Bumps pack version from 4 to 5
- Updates `registry.yaml` SHA256 (`aaa4df7...` → `d691279...`) and version to match

## Why

`defaultManifestFiles` in the scanner package has always included `Pipfile`, but the pack definition did not. This meant the API (which uses the pack's `manifest_files` when the pack is loaded) would miss `Pipfile` while the CLI (which falls back to `scanner.DefaultManifestFiles()`) would catch it. This PR closes the last gap; pack v5 and `defaultManifestFiles` are now in full parity.

Related: Upmate/pullminder.com#1620