### PR TITLE
fix(python-security): PY_UNSAFE_DESER matches yaml.load_all

### DIFF
--- a/packs/python-security/pack.yaml
+++ b/packs/python-security/pack.yaml
@@ -30,7 +30,7 @@ patterns:
 
   - name: Unsafe Deserialization
     rule_id: PY_UNSAFE_DESER
-    regex: '(?i)(pickle\.loads?|yaml\.load)\s*\('
+    regex: '(?i)(pickle\.loads?|yaml\.load(?:_all)?)\s*\('
     exclude_pattern: 'Loader\s*=\s*yaml\.(Safe|Full|Base)Loader'
     language: python
     severity: error

--- a/registry.yaml
+++ b/registry.yaml
@@ -35,7 +35,7 @@ packs:
     description: Python-specific security patterns including injection, deserialization, and framework misconfigurations
     default: false
     author: pullminder
-    sha256: d78353d4b3402f7f50520ed4d218d77dd62ebc9e7ee20b136bf00652694efc78
+    sha256: 2e3b8895630a7585ec3fafd44ad53bc0871cbffa0cc3c874fd13d6b3c9666895
 
   - slug: rust-security
     name: Rust Security


### PR DESCRIPTION
## Summary

- `yaml.load_all()` without an explicit `Loader` argument is as unsafe as `yaml.load()` — it uses Python's default full Loader and can deserialize arbitrary objects
- Extend the `PY_UNSAFE_DESER` regex from `yaml\.load` to `yaml\.load(?:_all)?` so both functions are flagged
- The existing `exclude_pattern` (`Loader\s*=\s*yaml\.(Safe|Full|Base)Loader`) already suppresses safe usage of `yaml.load_all`, so no change is needed there

## Regex change

Before: `(?i)(pickle\.loads?|yaml\.load)\s*\(`
After:  `(?i)(pickle\.loads?|yaml\.load(?:_all)?)\s*\(`

## Test plan

- [ ] `yaml.load_all(stream)` → fires PY_UNSAFE_DESER
- [ ] `yaml.load_all(stream, Loader=yaml.SafeLoader)` → silent
- [ ] `yaml.safe_load_all(stream)` → silent (safe variant does not match)
- [ ] `yaml.load(stream)` → still fires (regression)
- [ ] `pickle.loads(payload)` → still fires (regression)