### PR TITLE
fix(packs): backport JSON improvements to YAML for go-security, python-security, secrets

### DIFF
--- a/packs/go-security/pack.yaml
+++ b/packs/go-security/pack.yaml
@@ -123,7 +123,8 @@ patterns:
     severity: warning
     category: insecure_pattern
     exclude_pattern: '(?i)(errgroup|WaitGroup|wg\.Add|wg\.Done|\.Go\(|done\s*<-|context\.WithCancel|context\.WithTimeout)'
-    suggestion: "Ensure goroutine lifecycle is managed via WaitGroup, errgroup.Go(), or a done channel to prevent resource leaks"
+    fix_templates:
+      go: "Ensure goroutine lifecycle is managed via WaitGroup, errgroup.Go(), or a done channel to prevent resource leaks"
 
   - name: Unchecked database call error
     rule_id: GO_UNCHECKED_ERR_DB
@@ -132,7 +133,8 @@ patterns:
     severity: warning
     category: insecure_pattern
     exclude_pattern: '^\s*\w+\s*[:=]|\bdefer\b|\breturn\b'
-    suggestion: "Capture and check the error returned by database calls"
+    fix_templates:
+      go: "Capture and check the error returned by database calls"
 
   - name: Unchecked filesystem/IO error
     rule_id: GO_UNCHECKED_ERR_IO
@@ -140,7 +142,8 @@ patterns:
     language: go
     severity: warning
     category: insecure_pattern
-    suggestion: "Always check errors from filesystem and I/O operations to detect permission failures or partial writes"
+    fix_templates:
+      go: "Always check errors from filesystem and I/O operations to detect permission failures or partial writes"
 
 overrides:
   scoring:

--- a/packs/go-security/pack.yaml
+++ b/packs/go-security/pack.yaml
@@ -119,18 +119,20 @@ patterns:
   - name: Unmanaged goroutine
     rule_id: GO_GOROUTINE_LEAK
     regex: '\bgo\s+func\s*\('
-    exclude_pattern: '(?i)(errgroup|WaitGroup|wg\.Add|wg\.Done|\.Go\(|done\s*<-|context\.WithCancel|context\.WithTimeout)'
     language: go
     severity: warning
     category: insecure_pattern
+    exclude_pattern: '(?i)(errgroup|WaitGroup|wg\.Add|wg\.Done|\.Go\(|done\s*<-|context\.WithCancel|context\.WithTimeout)'
+    suggestion: "Ensure goroutine lifecycle is managed via WaitGroup, errgroup.Go(), or a done channel to prevent resource leaks"
 
   - name: Unchecked database call error
     rule_id: GO_UNCHECKED_ERR_DB
     regex: '^\s*(db|stmt|tx|rows|conn|session)\.(Exec|ExecContext|Query|QueryContext|QueryRow|QueryRowContext|Prepare|PrepareContext|Begin|BeginTx|Rollback|Commit)\s*\('
-    exclude_pattern: '^\s*\w+\s*[:=]|\bdefer\b|\breturn\b'
     language: go
     severity: warning
     category: insecure_pattern
+    exclude_pattern: '^\s*\w+\s*[:=]|\bdefer\b|\breturn\b'
+    suggestion: "Capture and check the error returned by database calls"
 
   - name: Unchecked filesystem/IO error
     rule_id: GO_UNCHECKED_ERR_IO
@@ -138,6 +140,7 @@ patterns:
     language: go
     severity: warning
     category: insecure_pattern
+    suggestion: "Always check errors from filesystem and I/O operations to detect permission failures or partial writes"
 
 overrides:
   scoring:

--- a/packs/python-security/pack.yaml
+++ b/packs/python-security/pack.yaml
@@ -35,7 +35,8 @@ patterns:
     severity: error
     category: insecure_pattern
     exclude_pattern: 'Loader\s*=\s*yaml\.(Safe|Full|Base)Loader'
-    suggestion: "Use yaml.safe_load() instead of yaml.load()"
+    fix_templates:
+      python: "Use yaml.safe_load() instead of yaml.load()"
 
   - name: OS System Command
     rule_id: PY_OS_SYSTEM
@@ -47,7 +48,6 @@ patterns:
   - name: Eval Execution
     rule_id: PY_EVAL
     regex: '(?i)\beval\s*\('
-    exclude_pattern: '\.\s*eval\s*\('
     language: python
     severity: error
     category: insecure_pattern
@@ -65,21 +65,17 @@ patterns:
   - name: Weak Hash for Passwords
     rule_id: PY_WEAK_HASH
     regex: '(?i)hashlib\.(md5|sha1)\s*\('
-    exclude_pattern: '(?i)\b(?:etag|checksum|fingerprint|cache_key|file_hash|content_hash|usedforsecurity\s*=\s*False)\b'
     language: python
     severity: info
     category: insecure_pattern
     exclude_pattern: '(?i)\b(?:etag|checksum|fingerprint|cache_key|file_hash|content_hash|usedforsecurity\s*=\s*False)\b'
-    suggestion: "Use bcrypt or argon2 for password hashing"
+    fix_templates:
+      python: "Use bcrypt or argon2 for password hashing"
 
   - name: Django DEBUG=True
     rule_id: PY_DJANGO_DEBUG
     regex: '(?i)\bDEBUG\s*=\s*True'
     language: python
-    path_patterns:
-      - '**/settings.py'
-      - '**/settings/**/*.py'
-      - '**/*settings*.py'
     severity: warning
     category: insecure_pattern
     path_patterns:
@@ -109,7 +105,8 @@ patterns:
     language: python
     severity: error
     category: insecure_pattern
-    suggestion: "Use parameterized queries: text(\"SELECT * FROM t WHERE id = :id\").bindparams(id=value)"
+    fix_templates:
+      python: "Use parameterized queries: text(\"SELECT * FROM t WHERE id = :id\").bindparams(id=value)"
 
   - name: Assert for Security Checks
     rule_id: PY_ASSERT_SECURITY
@@ -132,7 +129,6 @@ patterns:
   - name: Exec Execution
     rule_id: PY_EXEC
     regex: '(?i)\bexec\s*\('
-    exclude_pattern: '\.\s*exec\s*\('
     language: python
     severity: error
     category: insecure_pattern
@@ -144,7 +140,8 @@ patterns:
     language: python
     severity: warning
     category: insecure_pattern
-    suggestion: "Use tempfile.NamedTemporaryFile() or tempfile.mkstemp() with proper permissions"
+    fix_templates:
+      python: "Use tempfile.NamedTemporaryFile() or tempfile.mkstemp() with proper permissions"
 
   - name: Flask Debug Mode
     rule_id: PY_FLASK_DEBUG

--- a/packs/python-security/pack.yaml
+++ b/packs/python-security/pack.yaml
@@ -31,12 +31,11 @@ patterns:
   - name: Unsafe Deserialization
     rule_id: PY_UNSAFE_DESER
     regex: '(?i)(pickle\.loads?|yaml\.load(?:_all)?)\s*\('
-    exclude_pattern: 'Loader\s*=\s*yaml\.(Safe|Full|Base)Loader'
     language: python
     severity: error
     category: insecure_pattern
-    fix_templates:
-      python: "Use yaml.safe_load() instead of yaml.load()"
+    exclude_pattern: 'Loader\s*=\s*yaml\.(Safe|Full|Base)Loader'
+    suggestion: "Use yaml.safe_load() instead of yaml.load()"
 
   - name: OS System Command
     rule_id: PY_OS_SYSTEM
@@ -52,6 +51,7 @@ patterns:
     language: python
     severity: error
     category: insecure_pattern
+    exclude_pattern: '\.\s*eval\s*\('
 
   - name: Hardcoded Credentials
     rule_id: PY_HARDCODED_CREDS
@@ -69,13 +69,17 @@ patterns:
     language: python
     severity: info
     category: insecure_pattern
-    fix_templates:
-      python: "Use bcrypt or argon2 for password hashing"
+    exclude_pattern: '(?i)\b(?:etag|checksum|fingerprint|cache_key|file_hash|content_hash|usedforsecurity\s*=\s*False)\b'
+    suggestion: "Use bcrypt or argon2 for password hashing"
 
   - name: Django DEBUG=True
     rule_id: PY_DJANGO_DEBUG
     regex: '(?i)\bDEBUG\s*=\s*True'
     language: python
+    path_patterns:
+      - '**/settings.py'
+      - '**/settings/**/*.py'
+      - '**/*settings*.py'
     severity: warning
     category: insecure_pattern
     path_patterns:
@@ -105,8 +109,7 @@ patterns:
     language: python
     severity: error
     category: insecure_pattern
-    fix_templates:
-      python: "Use parameterized queries: text(\"SELECT * FROM t WHERE id = :id\").bindparams(id=value)"
+    suggestion: "Use parameterized queries: text(\"SELECT * FROM t WHERE id = :id\").bindparams(id=value)"
 
   - name: Assert for Security Checks
     rule_id: PY_ASSERT_SECURITY
@@ -133,6 +136,7 @@ patterns:
     language: python
     severity: error
     category: insecure_pattern
+    exclude_pattern: '\.\s*exec\s*\('
 
   - name: Insecure Temp File
     rule_id: PY_TEMPFILE_INSECURE
@@ -140,8 +144,7 @@ patterns:
     language: python
     severity: warning
     category: insecure_pattern
-    fix_templates:
-      python: "Use tempfile.NamedTemporaryFile() or tempfile.mkstemp() with proper permissions"
+    suggestion: "Use tempfile.NamedTemporaryFile() or tempfile.mkstemp() with proper permissions"
 
   - name: Flask Debug Mode
     rule_id: PY_FLASK_DEBUG

--- a/registry.yaml
+++ b/registry.yaml
@@ -35,7 +35,7 @@ packs:
     description: Python-specific security patterns including injection, deserialization, and framework misconfigurations
     default: false
     author: pullminder
-    sha256: 59434996b6c3510d8965ad8d62cc1d383e2f1397751c3f19a8b6956fc9c142c8
+    sha256: 208f47b844fac9093735a033c7e75b002ce882b44c8e88cd8a0536d17f9e2f75
 
   - slug: rust-security
     name: Rust Security

--- a/registry.yaml
+++ b/registry.yaml
@@ -23,7 +23,7 @@ packs:
     description: Go-specific security patterns including SQL injection, command injection, TLS, and unsafe usage
     default: false
     author: pullminder
-    sha256: 84f6139d5d3afe05356576e7f97d4ef8cfd6f82bd39dec5f32d841b95e05e495
+    sha256: 6876cf96044586f9657f4c30a50c81108d868c1e0c9329e29e22ec819046a26a
 
   - slug: python-security
     name: Python Security
@@ -35,7 +35,7 @@ packs:
     description: Python-specific security patterns including injection, deserialization, and framework misconfigurations
     default: false
     author: pullminder
-    sha256: f660ce0d61151b7822eea5fc05c457d3bf93029bc528fe3b247aaafe756e213d
+    sha256: 59434996b6c3510d8965ad8d62cc1d383e2f1397751c3f19a8b6956fc9c142c8
 
   - slug: rust-security
     name: Rust Security

--- a/registry.yaml
+++ b/registry.yaml
@@ -23,7 +23,7 @@ packs:
     description: Go-specific security patterns including SQL injection, command injection, TLS, and unsafe usage
     default: false
     author: pullminder
-    sha256: 99264b1dcc40ca4e3cef26c81944539315392f161b2c2b88e85258e67d450154
+    sha256: 84f6139d5d3afe05356576e7f97d4ef8cfd6f82bd39dec5f32d841b95e05e495
 
   - slug: python-security
     name: Python Security
@@ -35,7 +35,7 @@ packs:
     description: Python-specific security patterns including injection, deserialization, and framework misconfigurations
     default: false
     author: pullminder
-    sha256: ce125616a28a9a3741d23039ac01e256ab2f890e2cec81c04d55296ff86f16b9
+    sha256: f660ce0d61151b7822eea5fc05c457d3bf93029bc528fe3b247aaafe756e213d
 
   - slug: rust-security
     name: Rust Security

--- a/schema/pack.schema.json
+++ b/schema/pack.schema.json
@@ -115,6 +115,11 @@
             "items": { "type": "string" },
             "description": "Doublestar glob patterns the file path must match for this rule to fire. When non-empty, overrides language-based gating."
           },
+          "exclude_path_patterns": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Doublestar glob patterns for file paths where the rule must NOT fire. Exclude wins over path_patterns."
+          },
           "severity": {
             "type": "string",
             "enum": ["critical", "error", "warning", "info"],


### PR DESCRIPTION
## Summary

- **go-security (v4 → v5)**: Add three missing detection rules — `GO_GOROUTINE_LEAK` (unmanaged goroutines), `GO_UNCHECKED_ERR_DB` (unchecked database call errors), and `GO_UNCHECKED_ERR_IO` (unchecked filesystem/IO errors) — that existed in the JSON builtin but had never been backported to the YAML source. Each rule includes the correct `suggestion:` field, `exclude_pattern` where applicable, and matches the JSON exactly so `sync-registry` produces zero diff.
- **python-security (v5 → v6)**: Backport eight accumulated JSON improvements: `PY_UNSAFE_DESER` gains `yaml.load_all` coverage and a safe-Loader exclude; `PY_OS_SYSTEM` detects f-string interpolation; `PY_EVAL` and `PY_EXEC` add dot-method exclusions; `PY_WEAK_HASH` drops to `info` severity with etag/checksum exclusions; `PY_DJANGO_DEBUG` gains a word boundary and is scoped to settings file paths; `PY_SQLA_RAW` gains a word boundary and requires an f-string prefix; `PY_TEMPFILE_INSECURE` narrows to `mktemp` only.
- **secrets (v8 → v9)**: Restore the comment-line prefix alternation to `SECRET_CONNECTION_STRING.exclude_pattern`, preventing false positives when connection string examples appear in code comments.

All three `registry.yaml` version fields and sha256 checksums updated to match the edited `pack.yaml` files.

## Why

These three packs had YAML sources that lagged behind their JSON builtins. Running `sync-registry` on any pack would silently regress the JSON improvements — removing the three new go-security rules, reverting eight python-security pattern refinements, and stripping the comment-line exclusion from the secrets pack (which breaks `TestConnectionString_ExcludeCommentLines`). This PR makes YAML the authoritative source so future sync runs are safe.

Tracked in Upmate/pullminder.com#1810.

## Supersedes

This PR covers all individual python-security and secrets fixes currently in separate open branches (PRs #46, #47, #49, #51, #52, #53 for python-security; PRs #41 and the secrets portion of #54). Those PRs can be closed in favour of this one.

## Test plan

- [x] `sync-registry` produces zero diff for `go-security.json`, `python-security.json`, and `secrets.json`
- [x] All CLI tests pass (`go test ./...` in `apps/cli`)
- [x] All scanner tests pass (`go test ./...` in `packages/scanner`)
- [x] `TestConnectionString_ExcludeCommentLines` passes (no regression on secrets pack)