### PR TITLE
fix(react-security): scope REACT_DIRECT_DOM to JSX/TSX; add JS_INNERHTML_USERINPUT

### DIFF
--- a/packs/react-security/pack.yaml
+++ b/packs/react-security/pack.yaml
@@ -70,6 +70,7 @@ patterns:
     path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error
     category: insecure_pattern
+    exclude_pattern: '(?i)DOMPurify\.sanitize|\bsanitize\s*\(|\bsanitizeHtml\s*\(|\bxss\s*\(|purify\.clean'
     fix_templates:
       javascript: 'Sanitize user input before setting innerHTML. Use DOMPurify.sanitize(input) or assign to .textContent instead.'
 

--- a/packs/react-security/pack.yaml
+++ b/packs/react-security/pack.yaml
@@ -2,7 +2,7 @@ slug: react-security
 name: React & JavaScript Security
 kind: detection
 action: warn
-version: 5
+version: 10
 schema_version: 1
 author: pullminder
 max_weight: 10
@@ -22,11 +22,12 @@ patterns:
 
   - name: Dangerous HTML injection
     rule_id: REACT_DANGEROUS_HTML
-    regex: '(?i)__html\s*:\s*[^''"]'
+    regex: '(?i)__html\s*:\s*[^''\s"]'
     language: "*"
     path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error
     category: insecure_pattern
+    exclude_pattern: '(?i)DOMPurify\.sanitize|\bsanitize\s*\(|\bsanitizeHtml\s*\(|\bxss\s*\(|purify\.clean'
 
   - name: Use of eval()
     rule_id: JS_EVAL
@@ -57,9 +58,20 @@ patterns:
     rule_id: REACT_DIRECT_DOM
     regex: '(?i)document\.(getElementById|querySelector|getElementsBy)'
     language: "*"
-    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+    path_patterns: ["**/*.jsx", "**/*.tsx"]
     severity: warning
     category: insecure_pattern
+    exclude_pattern: '(?i)\.textContent\s*=|\.(?:inner|outer)HTML\s*='
+
+  - name: innerHTML/outerHTML with user-controlled input
+    rule_id: JS_INNERHTML_USERINPUT
+    regex: '(?i)document\.(getElementById|querySelector|getElementsBy)[^;]*\.(?:inner|outer)HTML\s*=.*(?:\.val\(\)|\.value\b|event\.(target|data)|req\.|params\.|query\.|userInput|formData)'
+    language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+    severity: error
+    category: insecure_pattern
+    fix_templates:
+      javascript: 'Sanitize user input before setting innerHTML. Use DOMPurify.sanitize(input) or assign to .textContent instead.'
 
   - name: document.write() usage
     rule_id: JS_DOCUMENT_WRITE
@@ -83,7 +95,7 @@ patterns:
 
   - name: window.open with user URLs
     rule_id: JS_WINDOW_OPEN
-    regex: '(?i)window\.open\s*\(.*(?:params|query|input|user|req)'
+    regex: '(?i)window\.open\s*\(\s*(?:params|query|input|user|req)'
     language: "*"
     path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error
@@ -101,7 +113,7 @@ patterns:
 
   - name: Prototype pollution
     rule_id: JS_PROTO_POLLUTION
-    regex: '(?i)(__proto__|constructor\.prototype|Object\.assign\s*\(\s*\{\})'
+    regex: '(?i)(__proto__|constructor\.prototype)'
     language: "*"
     path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error
@@ -119,9 +131,9 @@ patterns:
     fix_templates:
       javascript: 'Use httpOnly cookies instead of localStorage for sensitive tokens'
 
-  - name: outerHTML assignment
+  - name: innerHTML/outerHTML assignment
     rule_id: JS_INNERHTML_ASSIGN
-    regex: '(?i)\.outerHTML\s*='
+    regex: '(?i)\.(?:inner|outer)HTML\s*='
     language: "*"
     path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error
@@ -129,7 +141,7 @@ patterns:
 
   - name: Unescaped template literals in DOM
     rule_id: JS_TEMPLATE_UNESCAPED
-    regex: '(?i)\$\{.*\}.*\.innerHTML'
+    regex: '(?i)\.innerHTML\s*=.*\$\{'
     language: "*"
     path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error

--- a/registry.yaml
+++ b/registry.yaml
@@ -83,7 +83,7 @@ packs:
     description: React/JS XSS, DOM manipulation, prototype pollution, and open redirect patterns
     default: false
     author: pullminder
-    sha256: bba0b2694bfe16ca9abdbc5bdc0d092e0c959709a691c416763fbd7f00c9084c
+    sha256: ce720b735dbae98827cc69de9618c336f291deb61c6ed250ac964ec23730f6e6
 
   - slug: infra-security
     name: Infrastructure Security

--- a/registry.yaml
+++ b/registry.yaml
@@ -77,13 +77,13 @@ packs:
     name: React & JavaScript Security
     kind: detection
     action: warn
-    version: 5
+    version: 10
     tags: [react, javascript, xss, dom, prototype]
     languages: [javascript, typescript]
     description: React/JS XSS, DOM manipulation, prototype pollution, and open redirect patterns
     default: false
     author: pullminder
-    sha256: 71869e53ad87c93999bb9fb00ffd95ce1d59d93321ff1a7c22f89eeb60ebe65e
+    sha256: bba0b2694bfe16ca9abdbc5bdc0d092e0c959709a691c416763fbd7f00c9084c
 
   - slug: infra-security
     name: Infrastructure Security


### PR DESCRIPTION
## Summary

- `REACT_DIRECT_DOM` was firing on all `.js` and `.ts` files where `document.getElementById/querySelector` is idiomatic and correct, not an anti-pattern. The rule's scope is React architectural concerns (bypassing the virtual DOM), which only apply to `.jsx`/`.tsx` files. Narrowed `path_patterns` to `["**/*.jsx", "**/*.tsx"]`.
- `REACT_DIRECT_DOM` was also firing on safe `.textContent =` chained assignments (textContent always HTML-escapes, cannot cause XSS) and on `.innerHTML =` / `.outerHTML =` assignments (double-reporting with `JS_INNERHTML_ASSIGN`). Added `exclude_pattern` to suppress both.
- New rule `JS_INNERHTML_USERINPUT` (error severity, all four JS/TS file types): fires when a DOM selector call, an innerHTML/outerHTML sink, and a recognized user-input taint source all appear on the same line. Suppressed when the value passes through a known sanitizer (DOMPurify, sanitize(), etc.).
- Back-ported parity fixes from the monorepo (version 5 → 10): `JS_INNERHTML_ASSIGN` broadened to catch innerHTML too, `JS_TEMPLATE_UNESCAPED` regex order corrected, `JS_WINDOW_OPEN` tightened to first argument only, `JS_PROTO_POLLUTION` `Object.assign({})` arm removed, `REACT_DANGEROUS_HTML` sanitizer allowlist added.

## Evidence

From QA audit finding #7 (Upmate/pullminder.com#1601, part of audit Upmate/pullminder.com#1481):

- `site/js/user.elements.js:847`: `REACT_DIRECT_DOM` fired on `document.getElementById(...).innerHTML = serverData` in a vanilla JS file. Bot recommended DOMPurify.sanitize() despite the value being server-controlled, not user-supplied.
- `REACT_DIRECT_DOM` fired on `.textContent =` chained assignments, which are XSS-safe by definition.
- `REACT_DIRECT_DOM` fired on `.setAttribute` calls on the same line as a DOM selector.

## Test plan

- [ ] Registry schema validation passes on the updated `pack.yaml`
- [ ] `REACT_DIRECT_DOM` does not fire on `document.getElementById("x")` in a `.js` or `.ts` file
- [ ] `REACT_DIRECT_DOM` still fires in `.jsx`/`.tsx` files on bare DOM selector calls
- [ ] `REACT_DIRECT_DOM` does not fire when chained to `.textContent =`
- [ ] `JS_INNERHTML_USERINPUT` fires on `document.getElementById("x").innerHTML = req.body.html`
- [ ] `JS_INNERHTML_USERINPUT` does not fire when the RHS is a local variable without a taint keyword
- [ ] `JS_INNERHTML_USERINPUT` does not fire when the value passes through DOMPurify.sanitize()