### PR TITLE
feat(react-security): add JS_INNERHTML_USERINPUT multi-line taint detection rule

### DIFF
--- a/packs/react-security/pack.yaml
+++ b/packs/react-security/pack.yaml
@@ -2,7 +2,7 @@ slug: react-security
 name: React & JavaScript Security
 kind: detection
 action: warn
-version: 5
+version: 6
 schema_version: 1
 author: pullminder
 max_weight: 10
@@ -142,6 +142,19 @@ patterns:
     path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
     severity: error
     category: insecure_pattern
+
+  - name: innerHTML/outerHTML assignment with user-controlled input
+    rule_id: JS_INNERHTML_USERINPUT
+    regex: '(?is)(req\.|event\.target|location\.(?:search|hash)|url\.searchParams|\.value\b|\.query\b|\.params\b|\.body\b|\.files\b|response\.(?:text|data|json)\b|\.responseText\b)[\s\S]*?\.(?:inner|outer)HTML\s*='
+    language: "*"
+    path_patterns: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+    severity: error
+    category: insecure_pattern
+    window_lines: 3
+    fix_templates:
+      javascript: 'Sanitize user input with DOMPurify.sanitize() before assigning to innerHTML.'
+      typescript: 'Sanitize user input with DOMPurify.sanitize() before assigning to innerHTML.'
+    exclude_pattern: '(?i)DOMPurify\.sanitize|\bsanitize\s*\(|\bsanitizeHtml\s*\(|\bxss\s*\(|purify\.clean'
 
 overrides:
   scoring:


### PR DESCRIPTION
## Summary

- Adds `JS_INNERHTML_USERINPUT` rule with `window_lines: 3` to detect DOM XSS where user-controlled input is assigned to `innerHTML`/`outerHTML` within 3 lines.
- Taint sources detected: `req.`, `event.target`, `location.search/hash`, `url.searchParams`, `.value`, `.query`, `.params`, `.body`, `.files`, `response.text/data/json`, `.responseText`.
- An `exclude_pattern` suppresses the rule when `DOMPurify.sanitize()`, `sanitize()`, or `purify.clean` appears in the same window.
- Bumps react-security pack version from 5 to 6.

## Why

The existing `JS_INNERHTML_ASSIGN` fires on every `innerHTML`/`outerHTML` assignment regardless of whether the value comes from user input. This new rule specifically catches the multi-line pattern (source on line N, sink on line N+2) that the single-line rule misses.

Related: pullminder.com#1818, pullminder.com#1601