### PR TITLE
fix(crypto-anti-patterns): extend CRYPTO_ECB_MODE to match JSON config form

### DIFF
--- a/packs/crypto-anti-patterns/pack.yaml
+++ b/packs/crypto-anti-patterns/pack.yaml
@@ -32,7 +32,7 @@ patterns:
 
   - name: ECB mode usage
     rule_id: CRYPTO_ECB_MODE
-    regex: '(?i)(?:["\x{27}](?:AES|DES)/ECB|ECB_MODE|MODE_ECB|mode:\s*["\x{27}]?ecb)'
+    regex: '(?i)(?:["\x{27}](?:AES|DES)/ECB|ECB_MODE|MODE_ECB|["\x{27}]?mode["\x{27}]?\s*[:=]\s*["\x{27}]?ecb)'
     language: "*"
     severity: error
     category: insecure_pattern


### PR DESCRIPTION
## Summary

- Extends the `CRYPTO_ECB_MODE` rule to detect ECB mode specified as a JSON property (`"mode": "ecb"`)
- Replaces the old `mode:\s*["']?ecb` alternative with `["']?mode["']?\s*[:=]\s*["']?ecb`, which tolerates optional quotes around the key and accepts either `:` or `=` as the separator
- All existing YAML true positives (`mode: ecb`, `mode: 'ecb'`, `AES/ECB`, `DES/ECB`, `ECB_MODE`, `MODE_ECB`) are preserved
- New coverage includes: `"mode": "ecb"` (JSON), `'mode': 'ecb'` (single-quoted), `mode = "ecb"` (assignment)

## Problem

JSON configuration files (Docker Compose, `config.json`, application settings) that specify `"mode": "ecb"` were not flagged. The closing quote on the JSON key name (`"mode"`) sat between `mode` and `:`, preventing the `mode:` literal from matching.

## Test plan

- [ ] `CRYPTO_ECB_MODE` fires on `"mode": "ecb"` (core missed case)
- [ ] All existing YAML TPs still fire: `mode: ecb`, `mode: 'ecb'`, `AES/ECB`, `DES/ECB`, `ECB_MODE`, `MODE_ECB`
- [ ] FP guards clean: `"mode": "cbc"`, `"mode": "gcm"`, `mode: cbc`
- [ ] Regex compiles under RE2 (no lookarounds, no backreferences)
- [ ] Corresponding CLI test update in `Upmate/pullminder.com#1616`