### PR TITLE
fix(sensitive-paths): add .example exclusion to deploy/ path entry

### DIFF
--- a/packs/sensitive-paths/pack.yaml
+++ b/packs/sensitive-paths/pack.yaml
@@ -31,6 +31,8 @@ paths:
     label: Database migrations
   - pattern: "deploy/"
     label: Deployment
+    exclude_paths:
+      - ".example"
   - pattern: "payments/"
     label: Payments
   - pattern: "crypto/"


### PR DESCRIPTION
## Summary
- Add `.example` exclusion to the `deploy/` path entry in the sensitive-paths pack.
- Prevents false positives when `.env.example` or other example template files in the `deploy/` directory are flagged as sensitive path modifications.
- Example files ship placeholder values for operator documentation and are never production configuration.

Related: Upmate/pullminder.com#1868