### PR TITLE
feat(rust-security): adopt v7 pattern improvements from workspace snapshot

### DIFF
--- a/packs/rust-security/pack.yaml
+++ b/packs/rust-security/pack.yaml
@@ -2,7 +2,7 @@ slug: rust-security
 name: Rust Security
 kind: detection
 action: warn
-version: 5
+version: 7
 schema_version: 1
 author: pullminder
 max_weight: 10
@@ -23,7 +23,7 @@ patterns:
 
   - name: Raw SQL string formatting
     rule_id: RUST_SQL_FORMAT
-    regex: '(?i)format!\s*\(.*(?:SELECT|INSERT|UPDATE|DELETE|DROP|ALTER)'
+    regex: '(?i)format!\s*\(.*(?:SELECT|INSERT|UPDATE|DELETE|DROP|ALTER)\b'
     language: rust
     severity: error
     category: insecure_pattern
@@ -44,7 +44,7 @@ patterns:
 
   - name: Unwrap on network/IO result
     rule_id: RUST_UNWRAP_IO
-    regex: '\.(send|recv|connect|read|write|accept)\s*\([^)]*\)\s*\.unwrap\(\)'
+    regex: '(?:\.|::)(send|recv|connect|read_exact|read|write_all|write|flush|shutdown|bind|accept)\s*\([^)]*\)\s*\.unwrap\(\)'
     language: rust
     severity: warning
     category: insecure_pattern
@@ -60,7 +60,7 @@ patterns:
 
   - name: std::mem::transmute usage
     rule_id: RUST_TRANSMUTE
-    regex: '(?i)(mem::transmute|transmute::<)'
+    regex: '(?i)(mem::transmute[^_a-zA-Z0-9]|transmute::<)'
     language: rust
     severity: error
     category: insecure_pattern
@@ -94,7 +94,7 @@ patterns:
 
   - name: Unwrap on parse/conversion
     rule_id: RUST_UNWRAP_PARSE
-    regex: '\.(parse|from_str|try_into|try_from)\s*\([^)]*\)\s*\.unwrap\(\)'
+    regex: '\.(parse|from_str|try_into|try_from)(?:::<[^>]*>)?\s*\([^)]*\)\s*\.unwrap\(\)'
     language: rust
     severity: warning
     category: insecure_pattern
@@ -110,7 +110,7 @@ patterns:
 
   - name: Panic across FFI boundary
     rule_id: RUST_PANIC_IN_FFI
-    regex: '(?i)(panic!|unwrap|expect)\s*\(.*\).*// ?FFI'
+    regex: '(?i)extern\s+"C"\s+fn\s+\w+.*(?:panic!|\.unwrap\(\)|\.expect\()'
     language: rust
     severity: error
     category: insecure_pattern

--- a/registry.yaml
+++ b/registry.yaml
@@ -41,13 +41,13 @@ packs:
     name: Rust Security
     kind: detection
     action: warn
-    version: 5
+    version: 7
     tags: [rust, unsafe, memory, ffi, crypto]
     languages: [rust]
     description: Rust-specific security patterns including unsafe blocks, FFI boundaries, and deprecated crypto
     default: false
     author: pullminder
-    sha256: faabca3b63d05e17ecbe0f6554b52c4d06ab0e74d69671f22fb8b2c10fc9cef6
+    sha256: 932927de5d7d0e3e2d9d916b6f3a0fdbd8bbd7465a642b8f8b06ef8b4ec13e04
 
   - slug: ruby-security
     name: Ruby Security


### PR DESCRIPTION
## Summary
- Backport v7 regex improvements for rust-security pack from the CLI workspace snapshot
- RUST_SQL_FORMAT: add `\b` word boundary after SQL keyword alternation
- RUST_UNWRAP_IO: extend function list (send, recv, connect, read_exact, read, write_all, write, flush, shutdown, bind, accept) with `::` namespace prefix
- RUST_TRANSMUTE: add `[^_a-zA-Z0-9]` guard to prevent substring false positives on mem::transmute_count etc.
- RUST_UNWRAP_PARSE: add optional turbo-fish syntax `(?:::<[^>]*>)?` 
- RUST_PANIC_IN_FFI: match extern "C" function bodies containing panic/unwrap/expect instead of matching `// FFI` comment pattern
- Bumps version 5 -> 7, updates SHA256

## Test plan
- [ ] Registry validate passes against updated pack.yaml
- [ ] RE2 compatibility verified (no lookarounds in any regex)
- [ ] Diff review confirms only intended 5 pattern changes