### PR TITLE
fix(pii-leakage): add \b word boundaries to PII_PHONE regex

### DIFF
--- a/packs/pii-leakage/pack.yaml
+++ b/packs/pii-leakage/pack.yaml
@@ -35,7 +35,7 @@ patterns:
 
   - name: Phone number in code
     rule_id: PII_PHONE
-    regex: '(?i)(?:phone|mobile|tel|fax)\s*[:=]\s*["\x{27}]\+?\d[\d\s\-()]{8,}["\x{27}]'
+    regex: '(?i)\b(?:phone|mobile|tel|fax)\b\s*[:=]\s*["\x{27}]\+?\d[\d\s\-()]{8,}["\x{27}]'
     language: "*"
     severity: warning
     category: insecure_pattern


### PR DESCRIPTION
## Summary
- Adds `\b` word boundaries before and after the `(?:phone|mobile|tel|fax)` alternation in PII_PHONE
- Prevents false positives when identifiers like `hotel`, `motel`, `template` contain a keyword substring
- Complements the existing fix for PII_FIELD_LOG (`3c24ad3`) which added the same word boundary treatment