### PR TITLE
fix(php-security): add exclude_pattern to PHP_XSS to prevent false positives on sanitized output

### DIFF
--- a/packs/php-security/pack.yaml
+++ b/packs/php-security/pack.yaml
@@ -45,6 +45,7 @@ patterns:
   - name: Cross-Site Scripting (XSS)
     rule_id: PHP_XSS
     regex: '(?i)\becho\s+.*\$_(GET|POST|REQUEST|COOKIE)'
+    exclude_pattern: '(?i)\bhtmlspecialchars\b|\bhtmlentities\b|\bstrip_tags\b|\bintval\b|\bfloatval\b|\bfilter_input\b|\bfilter_var\b'
     language: php
     severity: error
     category: insecure_pattern


### PR DESCRIPTION
Add exclude_pattern to suppress findings when output is wrapped in safe sanitization functions (htmlspecialchars, htmlentities, strip_tags, intval, floatval, filter_input, filter_var).