### PR TITLE
fix(shell-security): expand SHELL_EVAL regex to detect shell special parameters

### DIFF
--- a/packs/shell-security/pack.yaml
+++ b/packs/shell-security/pack.yaml
@@ -21,7 +21,7 @@ patterns:
 
   - name: Eval on external input
     rule_id: SHELL_EVAL
-    regex: 'eval\s+.*\$(?:\{?\w+\}?|\()'
+    regex: 'eval\s+.*\$(?:\{?\w+\}?|[@*#?!-]|\()'
     language: shell
     severity: critical
     category: insecure_pattern


### PR DESCRIPTION
## Summary
- Mirrors the SHELL_EVAL regex change from `Upmate/pullminder.com#2052`
- Expands `eval\s+.*\$(?:\{?\w+\}?|\( )` to `eval\s+.*\$(?:\{?\w+\}?|[@*#?!-]|\( )`
- Catches `eval "$@"`, `eval $*`, and other shell special parameters previously missed by the `\w` character class

## Context
The `\w` word-character class (`[a-zA-Z0-9_]`) does not include `@`, `*`, `#`, `?`, `!`, `-`. This meant `eval "$@"` — one of the most common eval anti-patterns in shell wrapper scripts — was a false negative.

See `Upmate/pullminder.com#2052` for the full fix including test updates.