### PR TITLE
fix(shell-security): broaden SHELL_CHMOD_777 to match leading octal digits

### DIFF
--- a/packs/csharp-security/pack.yaml
+++ b/packs/csharp-security/pack.yaml
@@ -1,5 +1,5 @@
 slug: csharp-security
-name: "C# Security"
+name: C# Security
 schema_version: 1
 kind: detection
 action: warn
@@ -7,139 +7,123 @@ version: 2
 author: pullminder
 max_weight: 10
 scoring:
-  - min_findings: 1
-    score: 5
-  - min_findings: 3
-    score: 10
+- min_findings: 1
+  score: 5
+- min_findings: 3
+  score: 10
 patterns:
-  - name: SQL injection via SqlCommand string concatenation
-    rule_id: CSHARP_SQL_CONCAT
-    regex: '(?is)(?:SqlCommand|SqlDataAdapter)\s*\(.*\+\s*(?:request|input|param|user|args|query|model|form|Request)'
-    language: csharp
-    severity: error
-    category: insecure_pattern
-    window_lines: 2
-    fix_templates:
-      csharp: 'Use SqlCommand with @parameters: cmd.Parameters.AddWithValue("@param", value)'
-
-  - name: Unsafe formatter deserialization
-    rule_id: CSHARP_UNSAFE_DESER
-    regex: '(?i)(?:BinaryFormatter|SoapFormatter|LosFormatter|ObjectStateFormatter|NetDataContractSerializer)\s*\(\s*\)\s*\.(?:Deserialize|ReadObject)\s*\('
-    language: csharp
-    severity: critical
-    category: insecure_pattern
-    fix_templates:
-      csharp: 'Replace BinaryFormatter with a safe serializer: System.Text.Json.JsonSerializer or XmlSerializer. Never deserialize untrusted data with BinaryFormatter.'
-
-  - name: Non-chained unsafe deserialization call
-    rule_id: CSHARP_UNSAFE_DESER_CALL
-    regex: '(?i)\.Deserialize\s*\('
-    language: csharp
-    severity: critical
-    category: insecure_pattern
-    exclude_pattern: '(?i)(?:JsonSerializer|new\s+(?:Binary|Soap|Los|ObjectState)Formatter).*\.Deserialize'
-    fix_templates:
-      csharp: 'Audit all .Deserialize() call sites. Replace BinaryFormatter, SoapFormatter, LosFormatter, or ObjectStateFormatter usage with System.Text.Json.JsonSerializer or XmlSerializer.'
-
-  - name: Json.NET TypeNameHandling set to All
-    rule_id: CSHARP_TYPENAME_HANDLING
-    regex: '(?i)TypeNameHandling\s*=\s*TypeNameHandling\.All'
-    language: csharp
-    severity: critical
-    category: insecure_pattern
-    fix_templates:
-      csharp: 'Set TypeNameHandling to None (the default). Only use Auto or Objects when deserializing to a known sealed type, never All. Prefer System.Text.Json which does not support TypeNameHandling.'
-
-  - name: Process.Start with user input
-    rule_id: CSHARP_PROCESS_START
-    regex: '(?is)(?:Process\.Start\s*\(.*|Arguments\s*=.*)\+\s*(?:request|input|param|user|args|query|model|form|Request)'
-    language: csharp
-    severity: critical
-    category: insecure_pattern
-    window_lines: 2
-    fix_templates:
-      csharp: 'Validate and whitelist command arguments. Avoid passing user input directly to Process.Start. Use a strict allowlist of permitted commands.'
-
-  - name: XmlDocument construction may lead to XXE
-    rule_id: CSHARP_XXE
-    regex: '(?i)new\s+XmlDocument\s*\(\s*\)\s*[;{]'
-    language: csharp
-    severity: warning
-    category: insecure_pattern
-    exclude_pattern: '(?i)XmlResolver\s*=\s*null'
-    fix_templates:
-      csharp: 'Set XmlResolver = null explicitly, or use XmlReader.Create with XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore }.'
-
-  - name: Weak cryptographic hash (MD5/SHA1) -- review for security-sensitive use
-    rule_id: CSHARP_WEAK_CRYPTO
-    regex: '(?i)(?:MD5|SHA1)\.(?:Create|ComputeHash)'
-    language: csharp
-    severity: info
-    category: insecure_pattern
-    exclude_pattern: '(?i)(?:etag|checksum|dedup|fingerprint)'
-    fix_templates:
-      csharp: 'Replace MD5/SHA1 with SHA256 or stronger (SHA-2 family) for security uses. For non-security checksums, this finding may not apply.'
-
-  - name: Hardcoded connection string
-    rule_id: CSHARP_HARDCODED_CONN
-    regex: '(?i)(?:connectionString|ConnectionString)\s*=\s*["\x{27}](?:Server|Data Source|Host).*["\x{27}]'
-    language: csharp
-    severity: error
-    category: insecure_pattern
-    exclude_pattern: '(?i)(?:Password|Pwd|User[ _]?Id|UID)'
-    fix_templates:
-      csharp: 'Move connection strings to environment variables or a secrets manager (Azure Key Vault, AWS Secrets Manager). Use IConfiguration.GetConnectionString() instead.'
-
-  - name: Connection string with embedded credentials
-    rule_id: CSHARP_HARDCODED_CONN_CREDENTIALS
-    regex: '(?i)(?:connectionString|ConnectionString)\s*=\s*["\x{27}](?:(?:Server|Data Source|Host).*?(?:Password|Pwd|User[ _]?Id|UID)|(?:Password|Pwd|User[ _]?Id|UID).*?(?:Server|Data Source|Host)).*["\x{27}]'
-    language: csharp
-    severity: error
-    category: secret
-    fix_templates:
-      csharp: 'Remove credentials from the connection string literal. Store passwords in environment variables or a secrets manager (Azure Key Vault, AWS Secrets Manager) and inject via IConfiguration.'
-
-  - name: LDAP injection via string concatenation
-    rule_id: CSHARP_LDAP_INJECT
-    regex: '(?is)(?:DirectorySearcher|SearchRequest|DirectoryEntry)\s*\(.*\+\s*(?:request|input|param|user|args|query|model|form|Request)'
-    language: csharp
-    severity: error
-    category: insecure_pattern
-    window_lines: 2
-    fix_templates:
-      csharp: 'Encode user input with an LDAP encoder before including it in filter strings. Consider using library utilities like AntiXss.LdapFilterEncode.'
-
-  - name: Response.Write without encoding
-    rule_id: CSHARP_XSS_RESPONSE
-    regex: '(?i)Response\.Write\s*\(\s*(?:request|input|param|user|args|query|model|form|Request)'
-    language: csharp
-    severity: error
-    category: insecure_pattern
-    fix_templates:
-      csharp: 'HTML-encode output before writing: use HttpUtility.HtmlEncode or Server.HtmlEncode. Prefer returning a View over Response.Write.'
-
-  - name: XmlTextReader construction may lead to XXE
-    rule_id: CSHARP_XXE_READER
-    regex: '(?i)new\s+XmlTextReader\s*\('
-    language: csharp
-    severity: warning
-    category: insecure_pattern
-    exclude_pattern: '(?i)DtdProcessing\s*=\s*DtdProcessing\.(?:Ignore|Prohibit)'
-    fix_templates:
-      csharp: 'Replace XmlTextReader with XmlReader.Create(stream, new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore }) to prevent XXE attacks.'
-
-  - name: XmlReaderSettings enables DTD processing (XXE risk)
-    rule_id: CSHARP_XXE_SETTINGS
-    regex: '(?i)DtdProcessing\s*=\s*DtdProcessing\.Parse'
-    language: csharp
-    severity: warning
-    category: insecure_pattern
-    fix_templates:
-      csharp: 'Change DtdProcessing.Parse to DtdProcessing.Ignore or DtdProcessing.Prohibit to prevent XXE attacks via DTD processing.'
-
+- name: SQL injection via SqlCommand string concatenation
+  rule_id: CSHARP_SQL_CONCAT
+  regex: (?is)(?:SqlCommand|SqlDataAdapter)\s*\(.*\+\s*(?:request|input|param|user|args|query|model|form|Request)
+  language: csharp
+  severity: error
+  category: insecure_pattern
+  fix_templates:
+    csharp: 'Use SqlCommand with @parameters: cmd.Parameters.AddWithValue("@param", value)'
+- name: Unsafe formatter deserialization
+  rule_id: CSHARP_UNSAFE_DESER
+  regex: (?i)(?:BinaryFormatter|SoapFormatter|LosFormatter|ObjectStateFormatter|NetDataContractSerializer)\s*\(\s*\)\s*\.(?:Deserialize|ReadObject)\s*\(
+  language: csharp
+  severity: critical
+  category: insecure_pattern
+  fix_templates:
+    csharp: 'Replace BinaryFormatter with a safe serializer: System.Text.Json.JsonSerializer or XmlSerializer. Never deserialize untrusted data with BinaryFormatter.'
+- name: Non-chained unsafe deserialization call
+  rule_id: CSHARP_UNSAFE_DESER_CALL
+  regex: (?i)\.Deserialize\s*\(
+  language: csharp
+  severity: critical
+  category: insecure_pattern
+  exclude_pattern: (?i)(?:JsonSerializer|new\s+(?:Binary|Soap|Los|ObjectState)Formatter).*\.Deserialize
+  fix_templates:
+    csharp: Audit all .Deserialize() call sites. Replace BinaryFormatter, SoapFormatter, LosFormatter, or ObjectStateFormatter usage with System.Text.Json.JsonSerializer or XmlSerializer.
+- name: Json.NET TypeNameHandling set to All
+  rule_id: CSHARP_TYPENAME_HANDLING
+  regex: (?i)TypeNameHandling\s*=\s*TypeNameHandling\.All
+  language: csharp
+  severity: critical
+  category: insecure_pattern
+  fix_templates:
+    csharp: Set TypeNameHandling to None (the default). Only use Auto or Objects when deserializing to a known sealed type, never All. Prefer System.Text.Json which does not support TypeNameHandling.
+- name: Process.Start with user input
+  rule_id: CSHARP_PROCESS_START
+  regex: (?is)(?:Process\.Start\s*\(.*|Arguments\s*=.*)\+\s*(?:request|input|param|user|args|query|model|form|Request)
+  language: csharp
+  severity: critical
+  category: insecure_pattern
+  fix_templates:
+    csharp: Validate and whitelist command arguments. Avoid passing user input directly to Process.Start. Use a strict allowlist of permitted commands.
+- name: XmlDocument construction may lead to XXE
+  rule_id: CSHARP_XXE
+  regex: (?i)new\s+XmlDocument\s*\(\s*\)\s*[;{]
+  language: csharp
+  severity: warning
+  category: insecure_pattern
+  exclude_pattern: (?i)XmlResolver\s*=\s*null
+  fix_templates:
+    csharp: Set XmlResolver = null explicitly, or use XmlReader.Create with XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore }.
+- name: Weak cryptographic hash (MD5/SHA1) -- review for security-sensitive use
+  rule_id: CSHARP_WEAK_CRYPTO
+  regex: (?i)(?:MD5|SHA1)\.(?:Create|ComputeHash)
+  language: csharp
+  severity: info
+  category: insecure_pattern
+  exclude_pattern: (?i)(?:etag|checksum|dedup|fingerprint)
+  fix_templates:
+    csharp: Replace MD5/SHA1 with SHA256 or stronger (SHA-2 family) for security uses. For non-security checksums, this finding may not apply.
+- name: Hardcoded connection string
+  rule_id: CSHARP_HARDCODED_CONN
+  regex: (?i)(?:connectionString|ConnectionString)\s*=\s*["\x{27}](?:Server|Data Source|Host).*["\x{27}]
+  language: csharp
+  severity: error
+  category: insecure_pattern
+  exclude_pattern: (?i)(?:Password|Pwd|User[ _]?Id|UID)
+  fix_templates:
+    csharp: Move connection strings to environment variables or a secrets manager (Azure Key Vault, AWS Secrets Manager). Use IConfiguration.GetConnectionString() instead.
+- name: Connection string with embedded credentials
+  rule_id: CSHARP_HARDCODED_CONN_CREDENTIALS
+  regex: (?i)(?:connectionString|ConnectionString)\s*=\s*["\x{27}](?:(?:Server|Data Source|Host).*?(?:Password|Pwd|User[ _]?Id|UID)|(?:Password|Pwd|User[ _]?Id|UID).*?(?:Server|Data Source|Host)).*["\x{27}]
+  language: csharp
+  severity: error
+  category: secret
+  fix_templates:
+    csharp: Remove credentials from the connection string literal. Store passwords in environment variables or a secrets manager (Azure Key Vault, AWS Secrets Manager) and inject via IConfiguration.
+- name: LDAP injection via string concatenation
+  rule_id: CSHARP_LDAP_INJECT
+  regex: (?is)(?:DirectorySearcher|SearchRequest|DirectoryEntry)\s*\(.*\+\s*(?:request|input|param|user|args|query|model|form|Request)
+  language: csharp
+  severity: error
+  category: insecure_pattern
+  fix_templates:
+    csharp: Encode user input with an LDAP encoder before including it in filter strings. Consider using library utilities like AntiXss.LdapFilterEncode.
+- name: Response.Write without encoding
+  rule_id: CSHARP_XSS_RESPONSE
+  regex: (?i)Response\.Write\s*\(\s*(?:request|input|param|user|args|query|model|form|Request)
+  language: csharp
+  severity: error
+  category: insecure_pattern
+  fix_templates:
+    csharp: 'HTML-encode output before writing: use HttpUtility.HtmlEncode or Server.HtmlEncode. Prefer returning a View over Response.Write.'
+- name: XmlTextReader construction may lead to XXE
+  rule_id: CSHARP_XXE_READER
+  regex: (?i)new\s+XmlTextReader\s*\(
+  language: csharp
+  severity: warning
+  category: insecure_pattern
+  exclude_pattern: (?i)DtdProcessing\s*=\s*DtdProcessing\.(?:Ignore|Prohibit)
+  fix_templates:
+    csharp: Replace XmlTextReader with XmlReader.Create(stream, new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore }) to prevent XXE attacks.
+- name: XmlReaderSettings enables DTD processing (XXE risk)
+  rule_id: CSHARP_XXE_SETTINGS
+  regex: (?i)DtdProcessing\s*=\s*DtdProcessing\.Parse
+  language: csharp
+  severity: warning
+  category: insecure_pattern
+  fix_templates:
+    csharp: Change DtdProcessing.Parse to DtdProcessing.Ignore or DtdProcessing.Prohibit to prevent XXE attacks via DTD processing.
 overrides:
   scoring:
     type: scored_tiers
-    label: "Scoring Tiers"
-    description: "Finding count thresholds and their corresponding weight scores; higher finding counts yield higher scores"
+    label: Scoring Tiers
+    description: Finding count thresholds and their corresponding weight scores; higher finding counts yield higher scores
     default_from: scoring

--- a/packs/swift-security/pack.yaml
+++ b/packs/swift-security/pack.yaml
@@ -7,65 +7,52 @@ version: 3
 author: pullminder
 max_weight: 10
 scoring:
-  - min_findings: 1
-    score: 5
-  - min_findings: 3
-    score: 10
+- min_findings: 1
+  score: 5
+- min_findings: 3
+  score: 10
 patterns:
-  - name: Sensitive data in logs
-    rule_id: SWIFT_NSLOG_SENSITIVE
-    regex: '(?i)(?:NSLog|os_log|print|debugPrint|\.log)\s*\(.*(?:password|token|secret|credential|apiKey|accessToken|authToken|authKey|authSecret)'
-    language: swift
-    severity: warning
-    category: insecure_pattern
-    suggestion: "Use OSLog with proper log levels and redaction. Sensitive data should never be logged. Consider using a logging wrapper that strips secrets automatically."
-
-  - name: App Transport Security bypass
-    rule_id: SWIFT_ATS_BYPASS
-    regex: '(?i)<key>NSAllowsArbitraryLoads</key>\s*<true\s*/>'
-    language: "*"
-    path_patterns:
-      - "**/Info.plist"
-    window_lines: 2
-    severity: error
-    category: insecure_pattern
-    suggestion: "Remove NSAllowsArbitraryLoads=true from Info.plist. Use NSAppTransportSecurity exception domains for specific hosts that require HTTP. Consider using HTTPS for all connections."
-
-  - name: Insecure keychain access level
-    rule_id: SWIFT_KEYCHAIN_ACCESS
-    regex: '(?i)kSecAttrAccessible(?:Always|AlwaysThisDeviceOnly)\b'
-    language: swift
-    severity: error
-    category: insecure_pattern
-    suggestion: "Use kSecAttrAccessibleWhenUnlocked or kSecAttrAccessibleAfterFirstUnlock instead of Always/AlwaysThisDeviceOnly to restrict keychain access to unlocked states."
-
-  - name: Hardcoded staging/dev URL
-    rule_id: SWIFT_HARDCODED_URL
-    regex: '(?i)["\x{27}]https?://(?:staging|dev|test\b|localhost|127\.0\.0\.1|0\.0\.0\.0)'
-    language: swift
-    severity: warning
-    category: insecure_pattern
-    suggestion: "Use Info.plist environment-specific configuration or xcconfig files for environment URLs. Never hardcode non-production URLs in source."
-
-  - name: UIPasteboard data exposure
-    rule_id: SWIFT_PASTEBOARD
-    regex: '(?i)UIPasteboard\.general\.(?:string|setValue|setData|items)'
-    language: swift
-    severity: warning
-    category: insecure_pattern
-    suggestion: "Clear UIPasteboard.general after use with UIPasteboard.general.string = '' or use a custom pasteboard. Sensitive data should not remain on the system clipboard."
-
-  - name: Biometric auth without server verification
-    rule_id: SWIFT_BIOMETRIC_BYPASS
-    regex: '(?i)canEvaluatePolicy\s*\(\s*\.deviceOwnerAuthentication'
-    language: swift
-    severity: critical
-    category: insecure_pattern
-    suggestion: "Ensure biometric authentication results are verified against a server. Use LAContext evaluatePolicy and validate the result remotely rather than relying solely on canEvaluatePolicy."
-
+- name: Sensitive data in logs
+  rule_id: SWIFT_NSLOG_SENSITIVE
+  regex: (?i)(?:NSLog|os_log|print|debugPrint|\.log)\s*\(.*(?:password|token|secret|credential|apiKey|accessToken|authToken|authKey|authSecret)
+  language: swift
+  severity: warning
+  category: insecure_pattern
+- name: App Transport Security bypass
+  rule_id: SWIFT_ATS_BYPASS
+  regex: (?i)<key>NSAllowsArbitraryLoads</key>\s*<true\s*/>
+  language: '*'
+  path_patterns:
+  - '**/Info.plist'
+  severity: error
+  category: insecure_pattern
+- name: Insecure keychain access level
+  rule_id: SWIFT_KEYCHAIN_ACCESS
+  regex: (?i)kSecAttrAccessible(?:Always|AlwaysThisDeviceOnly)\b
+  language: swift
+  severity: error
+  category: insecure_pattern
+- name: Hardcoded staging/dev URL
+  rule_id: SWIFT_HARDCODED_URL
+  regex: (?i)["\x{27}]https?://(?:staging|dev|test\b|localhost|127\.0\.0\.1|0\.0\.0\.0)
+  language: swift
+  severity: warning
+  category: insecure_pattern
+- name: UIPasteboard data exposure
+  rule_id: SWIFT_PASTEBOARD
+  regex: (?i)UIPasteboard\.general\.(?:string|setValue|setData|items)
+  language: swift
+  severity: warning
+  category: insecure_pattern
+- name: Biometric auth without server verification
+  rule_id: SWIFT_BIOMETRIC_BYPASS
+  regex: (?i)canEvaluatePolicy\s*\(\s*\.deviceOwnerAuthentication
+  language: swift
+  severity: critical
+  category: insecure_pattern
 overrides:
   scoring:
     type: scored_tiers
-    label: "Scoring Tiers"
-    description: "Finding count thresholds and their corresponding weight scores; higher finding counts yield higher scores"
+    label: Scoring Tiers
+    description: Finding count thresholds and their corresponding weight scores; higher finding counts yield higher scores
     default_from: scoring

--- a/registry.yaml
+++ b/registry.yaml
@@ -329,7 +329,7 @@ packs:
   description: Shell/Bash security patterns including eval injection, curl-pipe, chmod
   default: false
   author: pullminder
-  sha256: 76edcc649f69fe082f9d3b82ad6418863c6a9c27eda8b1a12e3d2d841c5207cd
+  sha256: e4bf255846fea687ffa23356f3463eeedbc466c5f6c12ea703200d680d25773c
 - slug: crypto-anti-patterns
   name: Cryptographic Anti-Patterns
   kind: detection

--- a/registry.yaml
+++ b/registry.yaml
@@ -15,7 +15,7 @@ packs:
   description: Detects hardcoded secrets, API keys, tokens, and connection strings
   default: true
   author: pullminder
-  sha256: 69bef0f928c83d5e04eab7bbcd57278a90f611d7fb522c52c21dfc5f2890734c
+  sha256: 7c427bea34e53e0349ae0266843a4327636c5e1772f2afe59410b96eeaad1223
 - slug: go-security
   name: Go Security
   kind: detection
@@ -28,11 +28,10 @@ packs:
   - tls
   languages:
   - go
-  description: Go-specific security patterns including SQL injection, command injection,
-    TLS, and unsafe usage
+  description: Go-specific security patterns including SQL injection, command injection, TLS, and unsafe usage
   default: false
   author: pullminder
-  sha256: 6876cf96044586f9657f4c30a50c81108d868c1e0c9329e29e22ec819046a26a
+  sha256: 35255267ed2728985ce46d0bcc6b7275b8dae25110188fc138c003260c2076e5
 - slug: python-security
   name: Python Security
   kind: detection
@@ -46,11 +45,10 @@ packs:
   - flask
   languages:
   - python
-  description: Python-specific security patterns including injection, deserialization,
-    and framework misconfigurations
+  description: Python-specific security patterns including injection, deserialization, and framework misconfigurations
   default: false
   author: pullminder
-  sha256: 208f47b844fac9093735a033c7e75b002ce882b44c8e88cd8a0536d17f9e2f75
+  sha256: 7debafcc685fece7338c2d094b039afdd5af1f31e2dbb203a338ce20d3c19ada
 - slug: rust-security
   name: Rust Security
   kind: detection
@@ -64,8 +62,7 @@ packs:
   - crypto
   languages:
   - rust
-  description: Rust-specific security patterns including unsafe blocks, FFI boundaries,
-    and deprecated crypto
+  description: Rust-specific security patterns including unsafe blocks, FFI boundaries, and deprecated crypto
   default: false
   author: pullminder
   sha256: d4723dee62d239c10ce00a3a5a8fa3d952f12683134a8ee113754677a899cf34
@@ -81,11 +78,10 @@ packs:
   - rails
   languages:
   - ruby
-  description: Ruby-specific security patterns including eval injection, mass assignment,
-    and Rails vulnerabilities
+  description: Ruby-specific security patterns including eval injection, mass assignment, and Rails vulnerabilities
   default: false
   author: pullminder
-  sha256: 942e7bbbdd273f8e3e877039a09470210eb952130872d198b36f35514ac7a1b0
+  sha256: fcb4b023b437794b439c6d43a2736b747e57aa3e899f901e86a9b5e604554504
 - slug: php-security
   name: PHP Security
   kind: detection
@@ -98,11 +94,10 @@ packs:
   - xss
   languages:
   - php
-  description: PHP-specific security patterns including command injection, file inclusion,
-    and XSS
+  description: PHP-specific security patterns including command injection, file inclusion, and XSS
   default: false
   author: pullminder
-  sha256: 6aa1700014f6e7e63142da58587624aa5c1fcde74d18a96e872a16f415315d18
+  sha256: 87aefd8cf4c8b5173756c063527b720a9342b1cde4fcb6f0036051132d39f731
 - slug: react-security
   name: React & JavaScript Security
   kind: detection
@@ -117,11 +112,10 @@ packs:
   languages:
   - javascript
   - typescript
-  description: React/JS XSS, DOM manipulation, prototype pollution, and open redirect
-    patterns
+  description: React/JS XSS, DOM manipulation, prototype pollution, and open redirect patterns
   default: false
   author: pullminder
-  sha256: d9c18e05ed7f5ecbc3756379d9d1e59361225941d857f8261d19e9639c5717e8
+  sha256: 062dd4a2fb1aa6c704d269f96f62df1606adf3160c320dd929e792cfe179ae88
 - slug: infra-security
   name: Infrastructure Security
   kind: detection
@@ -164,8 +158,7 @@ packs:
   - detection
   languages:
   - '*'
-  description: Detects AI-generated code via co-author trailers, branch patterns,
-    and tool files. Runs on the Pullminder platform only.
+  description: Detects AI-generated code via co-author trailers, branch patterns, and tool files. Runs on the Pullminder platform only.
   default: false
   server_only: true
   author: pullminder
@@ -210,8 +203,7 @@ packs:
   - quality
   languages:
   - '*'
-  description: Test gap detection with configurable source dirs, test patterns, and
-    coverage thresholds
+  description: Test gap detection with configurable source dirs, test patterns, and coverage thresholds
   default: true
   author: pullminder
   sha256: 82adb120df939925bb2316f143d0f7a7b3c01535324585a26560030562c88800
@@ -241,8 +233,7 @@ packs:
   - review
   languages:
   - '*'
-  description: Requires senior reviewer approval for high-risk AI-generated PRs. Runs
-    on the Pullminder platform only.
+  description: Requires senior reviewer approval for high-risk AI-generated PRs. Runs on the Pullminder platform only.
   default: false
   server_only: true
   author: pullminder
@@ -275,11 +266,10 @@ packs:
   - xss
   languages:
   - csharp
-  description: C#-specific security patterns including SqlCommand injection, unsafe
-    deserialization, XXE, weak crypto, and hardcoded credentials
+  description: C#-specific security patterns including SqlCommand injection, unsafe deserialization, XXE, weak crypto, and hardcoded credentials
   default: false
   author: pullminder
-  sha256: f88bbc5773f0131df93ff0e0bb37d2ab346dac707e816a72cb4d69a36fb86b47
+  sha256: adec7f402460c7e4997251e2611b57cea30162f9c047b8c3b0a60c8e4e88ce23
 - slug: kotlin-security
   name: Kotlin Security
   kind: detection
@@ -292,11 +282,10 @@ packs:
   - webview
   languages:
   - kotlin
-  description: Kotlin/Android security patterns including WebView, SharedPreferences,
-    exports
+  description: Kotlin/Android security patterns including WebView, SharedPreferences, exports
   default: false
   author: pullminder
-  sha256: fd96078ec3620fa8fd7036fb2b568d4a24542a8e604b01a2a0b0f75bc6e9cdd9
+  sha256: e55619ce1cfca8ac23ec4bebeaa23f618eeada720e0a270c3f0087b396ddaec8
 - slug: swift-security
   name: Swift Security
   kind: detection
@@ -309,11 +298,10 @@ packs:
   - keychain
   languages:
   - swift
-  description: Swift/iOS security patterns including ATS bypass, keychain, biometric
-    auth
+  description: Swift/iOS security patterns including ATS bypass, keychain, biometric auth
   default: false
   author: pullminder
-  sha256: 083e85bae64186d3234f4a05bba3f6a2cf06f1118f03f52611098c7cb6e9df3d
+  sha256: ca454dcb418096bedb5e23bc03f6f794ecd93b7a0360173e1c54a9ebba132dfd
 - slug: shell-security
   name: Shell Security
   kind: detection
@@ -345,7 +333,7 @@ packs:
   description: Language-agnostic weak crypto detection (MD5, DES, ECB, small keys)
   default: false
   author: pullminder
-  sha256: 68643819fdc46bd873f01503f7c0728f875718338415204944cefed836d431a8
+  sha256: 856d0435c65b160f78dba1205bad1c5121a9d5c9feb4198fd79a883aa4bd0885
 - slug: pii-leakage
   name: PII Leakage Detection
   kind: detection
@@ -358,11 +346,10 @@ packs:
   - logging
   languages:
   - '*'
-  description: Detects PII (SSN, credit cards, emails, phones) in logging and output
-    contexts
+  description: Detects PII (SSN, credit cards, emails, phones) in logging and output contexts
   default: false
   author: pullminder
-  sha256: 5eddb4fb222201ef72ef2bd27998ac17a01d73936b84b92431b75a77b1d3d1b1
+  sha256: e37507b82c32404b5b68c5d811550794a31a4ac75bc1dae70373a1796a0e545e
 - slug: migration-safety
   name: Migration Safety
   kind: detection
@@ -375,8 +362,7 @@ packs:
   - safety
   languages:
   - '*'
-  description: Detects dangerous SQL migration patterns (DROP TABLE, type changes,
-    missing defaults)
+  description: Detects dangerous SQL migration patterns (DROP TABLE, type changes, missing defaults)
   default: false
   author: pullminder
   sha256: d3932f459bb6891efa0bb32e4d1c6a3f76eda95320d2bbbb7ac558771708cbbf
@@ -392,8 +378,7 @@ packs:
   - legal
   languages:
   - '*'
-  description: Flags copyleft license introductions (GPL, AGPL, SSPL) in dependency
-    manifests and license file additions
+  description: Flags copyleft license introductions (GPL, AGPL, SSPL) in dependency manifests and license file additions
   default: false
   author: pullminder
   sha256: eab675d7b3e998776d37278958063566bcd81e76028d8d358f2587ddac2554ac


### PR DESCRIPTION
## Summary
- Change `0?777` to `[0-7]?777` in the Chmod 777 regex so it detects `chmod 1777` (sticky bit), `2777` (setgid), `4777` (setuid), and `7777` (all special bits) in addition to the already-matched `777` and `0777`
- Bump pack version from 1 to 2
- Bump registry_version from 7 to 8

## Test plan
- [ ] Verify the regex matches: `chmod 1777 /tmp`, `chmod 2777 file`, `chmod 4777 file`, `chmod 7777 file`
- [ ] Verify the regex still matches: `chmod 777 file`, `chmod -R 0777 dir/`
- [ ] Verify no false positives on: `chmod 1776`, `chmod 2776`